### PR TITLE
Creating a github issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Basic Information
+
+* Platform (Mac, iOS, Android, Linux, etc): 
+* Built from source? (yes/no): 
+    * If yes, source branch/revision ID: 
+    * If no, release version:
+
+## Description of issue
+
+
+
+## Expected behaviour
+
+
+
+## Steps to reproduce issue
+


### PR DESCRIPTION
Many of the issues I've seen reported lack this basic information, making it hard to figure out whether they have been fixed or where to start looking.  This is a very basic template for people to fill out when creating a new issue so that we capture basic information.