### PR TITLE
Enable PTY, BasiliskII and pipe serial port also for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,12 @@ elseif (UNIX)
 			# Network card emulations
 			Emulator/Network/TUsermodeNetwork.cpp
 			Emulator/Network/TUsermodeNetwork.h
+			Emulator/Serial/TBasiliskIISerialPortManager.cpp
+			Emulator/Serial/TBasiliskIISerialPortManager.h
+			Emulator/Serial/TPipesSerialPortManager.cpp
+			Emulator/Serial/TPipesSerialPortManager.h
+			Emulator/Serial/TPtySerialPortManager.cpp
+			Emulator/Serial/TPtySerialPortManager.h
 			)
     set_property(GLOBAL PROPERTY USE_FOLDERS ON)
     source_group(TREE "${CMAKE_SOURCE_DIR}" PREFIX "Sources" FILES ${sources})

--- a/Emulator/Serial/TSerialPorts.cpp
+++ b/Emulator/Serial/TSerialPorts.cpp
@@ -40,7 +40,7 @@
 #include "Emulator/TEmulator.h"
 
 #include "Emulator/Serial/TBasicSerialPortManager.h"
-#if TARGET_OS_MAC
+#if TARGET_OS_MAC || TARGET_OS_LINUX
 #include "Emulator/Serial/TPipesSerialPortManager.h"
 #include "Emulator/Serial/TPtySerialPortManager.h"
 #include "Emulator/Serial/TBasiliskIISerialPortManager.h"
@@ -128,7 +128,7 @@ TSerialPortManager *TSerialPorts::ReplaceDriver(EPortIndex inPort, EDriverID inD
 		case kNullDriver:
 			currentDriver = new TBasicSerialPortManager(mLog, inPort);
 			break;
-#if TARGET_OS_MAC
+#if TARGET_OS_MAC || TARGET_OS_LINUX
 		case kPipesDriver:
 			currentDriver = new TPipesSerialPortManager(mLog, inPort);
 			break;
@@ -180,9 +180,9 @@ std::vector<const char*>TSerialPorts::ShortPortNames = /* NOLINT */
 };
 
 TSerialPorts::EDriverID TSerialPorts::ValidDrivers[] = {
-#if TARGET_OS_MAC
+#if TARGET_OS_MAC || TARGET_OS_LINUX
 	kNullDriver, kPipesDriver, kPtyDriver, kBasiliskIIDriver, kTcpClientDriver, (EDriverID)-1
-#elif TARGET_OS_ANDROID || TARGET_OS_LINUX || TARGET_OS_WIN32
+#elif TARGET_OS_ANDROID || TARGET_OS_WIN32
 	kNullDriver, kTcpClientDriver, (EDriverID)-1
 #else
 	kNullDriver, (EDriverID)-1


### PR DESCRIPTION
Basilisk II was tested ok, haven't yet tied the PTY and pipe drivers.