### PR TITLE
Enable selective logging of native primitives

### DIFF
--- a/Emulator/Log/TFileLog.cpp
+++ b/Emulator/Log/TFileLog.cpp
@@ -63,6 +63,7 @@ void
 TFileLog::DoLogLine( const char* inLine )
 {
 	(void) ::fprintf( mFile, "%s\n", inLine );
+	(void) ::fflush( mFile );
 }
 
 // ========================================================================= //

--- a/Emulator/TNativePrimitives.cpp
+++ b/Emulator/TNativePrimitives.cpp
@@ -73,6 +73,30 @@ struct NewtonPixmap {
 
 #define debugFlash 0
 
+#define ENABLE_LOG_PLATFORM (1 << 0x1)
+#define ENABLE_LOG_SOUND (1 << 0x2)
+#define ENABLE_LOG_BATTERY (1 << 0x3)
+#define ENABLE_LOG_SCREEN (1 << 0x4)
+#define ENABLE_LOG_TABLET (1 << 0x5)
+#define ENABLE_LOG_SERIAL (1 << 0x6)
+#define ENABLE_LOG_IN_TRANSLATOR (1 << 0x7)
+#define ENABLE_LOG_OUT_TRANSLATOR (1 << 0x8)
+#define ENABLE_LOG_HOSTCALL (1 << 0x9)
+#define ENABLE_LOG_NETWORKMANAGER (1 << 0xa)
+#define ENABLE_LOG_HOSTIOS_NATIVEIOS (1 << 0xb)
+
+#define LOG_PLATFORM (mLog && (mLogMask & ENABLE_LOG_PLATFORM))
+#define LOG_SOUND (mLog && (mLogMask & ENABLE_LOG_SOUND))
+#define LOG_BATTERY (mLog && (mLogMask & ENABLE_LOG_BATTERY))
+#define LOG_SCREEN (mLog && (mLogMask & ENABLE_LOG_SCREEN))
+#define LOG_TABLET (mLog && (mLogMask & ENABLE_LOG_TABLET))
+#define LOG_SERIAL (mLog && (mLogMask & ENABLE_LOG_SERIAL))
+#define LOG_IN_TRANSLATOR (mLog && (mLogMask & ENABLE_LOG_IN_TRANSLATOR))
+#define LOG_OUT_TRANSLATOR (mLog && (mLogMask & ENABLE_LOG_OUT_TRANSLATOR))
+#define LOG_HOSTCALL (mLog && (mLogMask & ENABLE_LOG_HOSTCALL))
+#define LOG_NETWORKMANAGER (mLog && (mLogMask & ENABLE_LOG_NETWORKMANAGER))
+#define LOG_HOSTIOS_NATIVEIOS (mLog && (mLogMask & ENABLE_LOG_HOSTIOS_NATIVEIOS))
+
 // -------------------------------------------------------------------------- //
 // Constantes
 // -------------------------------------------------------------------------- //
@@ -86,6 +110,7 @@ TNativePrimitives::TNativePrimitives(
 	:
 		mProcessor( nil ),
 		mLog( inLog ),
+		mLogMask( 0b000000000000 ),
 		mMemory( inMemory ),
 		mEmulator( nil ),
 		mNetworkManager( nil ),
@@ -577,14 +602,14 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 	switch (inInstruction & 0xFF)
 	{
 		case 0x01:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::New" );
 			}
 			break;
 			
 		case 0x02:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::Delete" );
 			}
@@ -592,7 +617,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 			
 		case 0x03:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::Init" );
 			}
@@ -600,7 +625,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 			
 		case 0x04:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::BacklightTrigger" );
 			}
@@ -608,7 +633,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 			
 		case 0x05:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::RegisterPowerSwitchInterrupt" );
 			}
@@ -616,7 +641,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 			
 		case 0x06:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::EnableSysPowerInterrupt" );
 			}
@@ -624,7 +649,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 			
 		case 0x07:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::InterruptHandler" );
 			}
@@ -632,7 +657,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 			
 		case 0x08:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::TimerInterruptHandler" );
 			}
@@ -640,7 +665,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 			
 		case 0x09:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::ResetZAPStoreCheck" );
 			}
@@ -654,7 +679,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
         // Inserting a PCMCIA card powers up 0x1d
         // Starting "Dock" creates 0x1d, starting serial com generates 0x01, 0x23, 0x22
 				KUInt32 theSubsystem = mProcessor->GetRegister(1);
-				if (mLog)
+				if (LOG_PLATFORM)
 				{
 					mLog->FLogLine(
 						"TMainPlatformDriver::PowerOnSubsystem( %.8X )",
@@ -678,7 +703,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 		case 0x0B:
 			{
 				KUInt32 theSubsystem = mProcessor->GetRegister(1);
-				if (mLog)
+				if (LOG_PLATFORM)
 				{
 					mLog->FLogLine(
 						"TMainPlatformDriver::PowerOffSubsystem( %.8X )",
@@ -691,27 +716,27 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 				mProcessor->SetRegister( 0, 0 );
 			}
 			break;
-			
+
 		case 0x0C:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::PowerOffAllSubsystems" );
 			}
 			mMemory->PowerOffFlash();
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0D:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 //				mLog->LogLine( "TMainPlatformDriver::PauseSystem" );
 			}
 			mEmulator->PauseSystem();
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0E:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::PowerOffSystem" );
 			}
@@ -725,9 +750,9 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0F:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::PowerOnSystem" );
 			}
@@ -735,9 +760,9 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			mPlatformManager->PowerOn();
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x10:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->FLogLine(
 					"TMainPlatformDriver::TranslatePowerEvent( %.8X )",
@@ -745,7 +770,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x11:
             // kPCMCIA5VAvailable   =    0x0001,    // 5.0 V available
             // kPCMCIA12VAvailable  =    0x0002,    // 12.0 V available
@@ -753,13 +778,13 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
             // kPCMCIAXpXVAvailable =    0x0008,    // X.X V available
             // kPCMCIAYpYVAvailable =    0x0010,    // Y.Y V available
             // kPCMCIA0VAvailable   =    0x0020     // 0 V available (for example: 0 V Vpp)
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->FLogLine(
 					"TMainPlatformDriver::GetPCMCIAPowerSpec( %.8X )",
 					(unsigned int) mProcessor->GetRegister(1) );
 			}
-			
+
 			if (mProcessor->GetRegister(1) == 0)
 			{
 				(void) mMemory->Write(
@@ -775,9 +800,9 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 				mProcessor->SetRegister( 0, (unsigned int) -10005 ); // "Call not implemented"
 			}
 			break;
-			
+
 		case 0x12:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->FLogLine(
 					"TMainPlatformDriver::PowerOnDeviceCheck( %.8X )",
@@ -800,9 +825,9 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x13:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->FLogLine(
 					"TMainPlatformDriver::SetSubsystemPower( %.8X, %.8X )",
@@ -811,9 +836,9 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x14:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->FLogLine(
 					"TMainPlatformDriver::GetSubsystemPower( %.8X )",
@@ -824,7 +849,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 				(unsigned int) 0 );
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x15:
 			// GetNextEvent.
 			{
@@ -837,16 +862,16 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x16:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::Hop!" );
 			}
 			mProcessor->SetRegister( 15, mProcessor->GetRegister( 15 ) + 4 );
 			mEmulator->BreakInMonitor("TMainPlatformDriver::Hop!");
 			break;
-			
+
 		case 0x17:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->LogLine( "TMainPlatformDriver::FillGestaltEmulatorInfo" );
 			}
@@ -855,7 +880,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 				(unsigned int) kUP2Version );
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x18:
 			mPlatformManager->LockEventQueue();
 			break;
@@ -973,7 +998,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x21:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->FLogLine("TMainPlatformDriver::OpenEinsteinMenu()");
 			}
@@ -981,7 +1006,7 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x22:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->FLogLine("TMainPlatformDriver::NewtonScriptCall()");
 			}
@@ -997,13 +1022,13 @@ TNativePrimitives::ExecutePlatformDriverNative( KUInt32 inInstruction )
 			break;
 
 		default:
-			if (mLog)
+			if (LOG_PLATFORM)
 			{
 				mLog->FLogLine(
 					"Unknown platform driver native primitive %.8X (pc=%.8X)",
 					(unsigned int) inInstruction,
 					(unsigned int) mProcessor->GetRegister(15) );
-			}					
+			}
 	}
 }
 
@@ -1018,32 +1043,32 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 	{
 			// No longer native.
 //		case 0x01:
-//			if (mLog)
+//			if (LOG_SOUND)
 //			{
 //				mLog->LogLine( "PMainSoundDriver::New" );
 //			}
 //			break;
-			
+
 			// No longer native.
 //		case 0x02:
-//			if (mLog)
+//			if (LOG_SOUND)
 //			{
 //				mLog->LogLine( "PMainSoundDriver::Delete" );
 //			}
 //			mProcessor->SetRegister( 0, 0 );
 //			break;
-			
+
 		case 0x03:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::SetSoundHardwareInfo" );
 			}
 			mProcessor->SetRegister( 0, (KUInt32) -30009 );
 			break;
-			
+
 		case 0x04:
 //			mEmulator->BreakInMonitor();
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::GetSoundHardwareInfo" );
 			}
@@ -1059,13 +1084,13 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x05:
 			{
 				// mEmulator->BreakInMonitor();
 				KUInt32 fourthParam;
 				(void) mMemory->Read(mProcessor->GetRegister(13) + 4, fourthParam);
-				if (mLog)
+				if (LOG_SOUND)
 				{
 					mLog->LogLine( "PMainSoundDriver::SetOutputBuffers(" );
 					mLog->FLogLine(
@@ -1082,13 +1107,13 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x06:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				KUInt32 fourthParam;
 				(void) mMemory->Read(mProcessor->GetRegister(13) + 4, fourthParam);
-				
+
 				mLog->LogLine( "PMainSoundDriver::SetInputBuffers(" );
 				mLog->FLogLine(
 					"  %.8X, %.8X, %.8X, %.8X )",
@@ -1099,9 +1124,9 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x07:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->FLogLine(
 					"PMainSoundDriver::ScheduleOutputBuffer( %.8X, %.8X )",
@@ -1121,9 +1146,9 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x08:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->FLogLine(
 					"PMainSoundDriver::ScheduleInputBuffer( %.8X, %.8X )",
@@ -1132,9 +1157,9 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x09:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->FLogLine(
 					"PMainSoundDriver::PowerOutputOn( %i )",
@@ -1142,115 +1167,115 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0A:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::PowerOutputOff" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0B:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::PowerInputOn" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0C:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::PowerInputOff" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0D:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::StartOutput" );
 			}
 			mSoundManager->StartOutput();
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0E:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::StartInput" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0F:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::StopOutput" );
 			}
 			mSoundManager->StopOutput();
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x10:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::StopInput" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x11:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::OutputIsEnabled" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x12:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::InputIsEnabled" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x13:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::OutputIsRunning" );
 			}
 			mProcessor->SetRegister( 0, mSoundManager->OutputIsRunning() );
 			break;
-			
+
 		case 0x14:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::InputIsRunning" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x15:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::CurrentOutputPtr" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x16:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::CurrentInputPtr" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x17:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->FLogLine(
 					"PMainSoundDriver::OutputVolume( %.8X )",
@@ -1259,17 +1284,17 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 			mSoundManager->OutputVolume( mProcessor->GetRegister(1) );
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x18:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::OutputVolume" );
 			}
 			mProcessor->SetRegister( 0, mSoundManager->OutputVolume() );
 			break;
-			
+
 		case 0x19:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->FLogLine(
 					"PMainSoundDriver::InputVolume( %.8X )",
@@ -1285,49 +1310,49 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x1A:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::InputVolume" );
 			}
 			mProcessor->SetRegister( 0, mInputVolume );
 			break;
-			
+
 		case 0x1B:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::EnableExtSoundSource" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x1C:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::DisableExtSoundSource" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x1D:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::OutputIntHandler" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x1E:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->LogLine( "PMainSoundDriver::InputIntHandler" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-		
+
 		case 0x1F:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->FLogLine(
 					"PMainSoundDriver::NativeSetInterruptMask( %.8X, %.8X )",
@@ -1338,16 +1363,16 @@ TNativePrimitives::ExecuteSoundDriverNative( KUInt32 inInstruction )
 				mProcessor->GetRegister(1),
 				mProcessor->GetRegister(2));
 			break;
-		
+
 
 		default:
-			if (mLog)
+			if (LOG_SOUND)
 			{
 				mLog->FLogLine(
 					"Unknown sound driver native primitive %.8X (pc=%.8X)",
 					(unsigned int) inInstruction,
 					(unsigned int) mProcessor->GetRegister(15) );
-			}					
+			}
 	}
 }
 
@@ -1360,66 +1385,66 @@ TNativePrimitives::ExecuteBatteryDriverNative( KUInt32 inInstruction )
 	switch (inInstruction & 0xFF)
 	{
 		case 0x01:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::New" );
 			}
 			break;
-			
+
 		case 0x02:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::Delete" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x03:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::Init" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x04:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::WakeUp" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x05:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::ShutDown" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x06:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::Count" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x07:
 			/*
 			 #import <IOKit/ps/IOPowerSources.h>
 			 #import <IOKit/ps/IOPSKeys.h>
 			 CFTypeRef               info;
 			 CFArrayRef              list;
-			 CFDictionaryRef         battery;			 
+			 CFDictionaryRef         battery;
 			 info = IOPSCopyPowerSourcesInfo();
 			 list = IOPSCopyPowerSourcesList(info);	// ->CFRelease(info);
 			 if(CFArrayGetCount(list) && (battery = IOPSGetPowerSourceDescription(info, CFArrayGetValueAtIndex(list, 0)))) {
 				outputCapacity = [[(NSDictionary*)battery objectForKey:@kIOPSCurrentCapacityKey] doubleValue];
 			 }
 			 */
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::Status" );
 			}
@@ -1438,12 +1463,12 @@ TNativePrimitives::ExecuteBatteryDriverNative( KUInt32 inInstruction )
 				(void) mMemory->Write(theInfoStructAddr + 0x28, 0xFFFFFFFF);	// mUnknownDIOPins33Related
 				(void) mMemory->Write(theInfoStructAddr + 0x2C, 0x001A2F28);	// mVoltage4
 				(void) mMemory->Write(theInfoStructAddr + 0x30, 0x001A8D79);	// mVoltage5
-			}			
+			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x08:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::RawStatus" );
 			}
@@ -1462,36 +1487,36 @@ TNativePrimitives::ExecuteBatteryDriverNative( KUInt32 inInstruction )
 				(void) mMemory->Write(theInfoStructAddr + 0x28, 0xFFFFFFFF);	// mUnknownDIOPins33Related
 				(void) mMemory->Write(theInfoStructAddr + 0x2C, 0x086E2000);	// mVoltage4
 				(void) mMemory->Write(theInfoStructAddr + 0x30, 0x07D3B000);	// mVoltage5
-			}			
+			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x09:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::StartSleepCharge" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0A:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::SetType" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0B:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::ReadADCVoltage" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0C:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->LogLine( "PMainBatteryDriver::ConvertVoltage" );
 			}
@@ -1499,13 +1524,13 @@ TNativePrimitives::ExecuteBatteryDriverNative( KUInt32 inInstruction )
 			break;
 
 		default:
-			if (mLog)
+			if (LOG_BATTERY)
 			{
 				mLog->FLogLine(
 					"Unknown battery driver native primitive %.8X (pc=%.8X)",
 					(unsigned int) inInstruction,
 					(unsigned int) mProcessor->GetRegister(15) );
-			}					
+			}
 	}
 }
 
@@ -1518,7 +1543,7 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 	switch (inInstruction & 0xFF)
 	{
 		case 0x01:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->LogLine( "TMainDisplayDriver::Delete" );
 			}
@@ -1526,7 +1551,7 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 			break;
 
 //		case 0x02:
-//			if (mLog)
+//			if (LOG_SCREEN)
 //			{
 //				mLog->LogLine( "TMainDisplayDriver::ScreenSetup" );
 //			}
@@ -1534,7 +1559,7 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 //			break;
 
 		case 0x03:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->LogLine( "TMainDisplayDriver::GetScreenInfo" );
 			}
@@ -1552,7 +1577,7 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x04:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->LogLine( "TMainDisplayDriver::PowerInit" );
 			}
@@ -1560,7 +1585,7 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x05:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->LogLine( "TMainDisplayDriver::PowerOn" );
 			}
@@ -1569,7 +1594,7 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x06:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->LogLine( "TMainDisplayDriver::PowerOff" );
 			}
@@ -1581,39 +1606,39 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 			{
 				KUInt32 theMode;
 				(void) mMemory->Read(mProcessor->GetRegister(13) + 4, theMode);
-				
+
 				//	ULong	Blit(PixelMap*, Rect*, Rect*, long);
 				TScreenManager::SRect srcRect;
-				
+
 				KUInt32 tmp = 0;
-				
+
 				(void) mMemory->Read(mProcessor->GetRegister(2), tmp);
 				srcRect.fTop = (KUInt16) (tmp >> 16);
 				srcRect.fLeft = (KUInt16) (tmp & 0x0000FFFF);
 				(void) mMemory->Read(mProcessor->GetRegister(2) + 4, tmp);
 				srcRect.fBottom = (KUInt16) (tmp >> 16);
 				srcRect.fRight = (KUInt16) (tmp & 0x0000FFFF);
-	
+
 				TScreenManager::SRect dstRect;
-	
+
 				(void) mMemory->Read(mProcessor->GetRegister(3), tmp);
 				dstRect.fTop = (KUInt16) (tmp >> 16);
 				dstRect.fLeft = (KUInt16) (tmp & 0x0000FFFF);
 				(void) mMemory->Read(mProcessor->GetRegister(3) + 4, tmp);
 				dstRect.fBottom = (KUInt16) (tmp >> 16);
 				dstRect.fRight = (KUInt16) (tmp & 0x0000FFFF);
-				
+
 				mScreenManager->Blit(
 					mProcessor->GetRegister(1),
 					&srcRect,
 					&dstRect,
 					theMode );
 				mProcessor->SetRegister( 0, 0 );
-			}			
+			}
 			break;
-			
+
 		case 0x08:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->FLogLine(
 					"TMainDisplayDriver::GetFeature( %.8X )",
@@ -1639,9 +1664,9 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 				}
 			}
 			break;
-			
+
 		case 0x09:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->FLogLine(
 					"TMainDisplayDriver::SetFeature( %.8X, %.8X )",
@@ -1663,7 +1688,7 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x0A:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->LogLine( "TMainDisplayDriver::AutoAdjustFeatures" );
 			}
@@ -1671,7 +1696,7 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x0B:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->FLogLine(
 					"TMainDisplayDriver::DoubleBlit( PM=%.8X, PM=%.8X, R=%.8X, R, long )",
@@ -1683,15 +1708,15 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x0C:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->LogLine( "TMainDisplayDriver::EnterIdleMode" );
 			}
 			mProcessor->SetRegister( 0, 0 );
 			break;
-			
+
 		case 0x0D:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->LogLine( "TMainDisplayDriver::ExitIdleMode" );
 			}
@@ -1699,13 +1724,13 @@ TNativePrimitives::ExecuteScreenDriverNative( KUInt32 inInstruction )
 			break;
 
 		default:
-			if (mLog)
+			if (LOG_SCREEN)
 			{
 				mLog->FLogLine(
 					"Unknown screen driver native primitive %.8X (pc=%.8X)",
 					(unsigned int) inInstruction,
 					(unsigned int) mProcessor->GetRegister(15) );
-			}					
+			}
 	}
 }
 
@@ -1719,14 +1744,14 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 	switch (inInstruction & 0xFF)
 	{
 		case 0x01:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::New" );
 			}
 			break;
 
 		case 0x02:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::Delete" );
 			}
@@ -1734,7 +1759,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x03:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::Init" );
 			}
@@ -1747,7 +1772,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x04:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::WakeUp" );
 			}
@@ -1756,7 +1781,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x05:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::ShutDown" );
 			}
@@ -1765,7 +1790,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x06:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::TabletIdle" );
 			}
@@ -1773,7 +1798,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x07:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::GetSampleRate" );
 			}
@@ -1781,7 +1806,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x08:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->FLogLine(
 					"TMainTabletDriver::SetSampleRate( %.8X )",
@@ -1793,7 +1818,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x09:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::GetTabletCalibration" );
 			}
@@ -1818,7 +1843,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x0A:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::SetTabletCalibration" );
 			}
@@ -1843,7 +1868,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x0B:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::SetDoingCalibration" );
 			}
@@ -1851,7 +1876,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x0C:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::GetTabletResolution" );
 				// mEmulator->BreakInMonitor();
@@ -1865,7 +1890,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x0D:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::TabSetOrientation" );
 			}
@@ -1875,7 +1900,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x0E:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 //				mLog->LogLine( "TMainTabletDriver::GetTabletState" );
 			}
@@ -1883,7 +1908,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x0F:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::GetFingerInputState" );
 			}
@@ -1891,7 +1916,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x10:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::SetFingerInputState" );
 			}
@@ -1899,7 +1924,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x11:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::RecalibrateTabletAfterRotate" );
 			}
@@ -1907,7 +1932,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x12:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::TabletNeedsRecalibration" );
 			}
@@ -1915,7 +1940,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x13:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::StartBypassTablet" );
 			}
@@ -1924,7 +1949,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x14:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::StopBypassTablet" );
 			}
@@ -1933,7 +1958,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x15:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->LogLine( "TMainTabletDriver::ReturnTabletToConsciousness" );
 			}
@@ -1941,7 +1966,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		case 0x16:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 //				mLog->LogLine( "TMainTabletDriver::NativeGetSample" );
 			}
@@ -1963,7 +1988,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 			break;
 
 		default:
-			if (mLog)
+			if (LOG_TABLET)
 			{
 				mLog->FLogLine(
 					"Unknown tablet driver native primitive %.8X (pc=%.8X)",
@@ -1983,7 +2008,7 @@ TNativePrimitives::ExecuteTabletDriverNative( KUInt32 inInstruction )
 void
 TNativePrimitives::ExecuteSerialDriverNative( KUInt32 inInstruction )
 {
-	if (mLog)
+	if (LOG_SERIAL)
 	{
 		KUInt32 theLocation = -1;
 		(void) mMemory->Read(mProcessor->GetRegister(0) + 16, theLocation);
@@ -1991,7 +2016,7 @@ TNativePrimitives::ExecuteSerialDriverNative( KUInt32 inInstruction )
 			"Hardware location (?) %.8X",
 			theLocation);
 	}
-			
+
 	switch (inInstruction & 0xFF)
 	{
 //		case 0x01:
@@ -2179,7 +2204,7 @@ TNativePrimitives::ExecuteSerialDriverNative( KUInt32 inInstruction )
 			break;
 
 		default:
-			if (mLog)
+			if (LOG_SERIAL)
 			{
 				mLog->FLogLine(
 					"Unknown serial driver native primitive %.8X (pc=%.8X)",
@@ -2201,7 +2226,7 @@ TNativePrimitives::ExecuteInTranslatorNative( KUInt32 inInstruction )
 	switch (inInstruction & 0xFF)
 	{
 		default:
-			if (mLog)
+			if (LOG_IN_TRANSLATOR)
 			{
 				mLog->FLogLine(
 					"Unknown in-translator native primitive %.8X (pc=%.8X)",
@@ -2221,7 +2246,7 @@ TNativePrimitives::ExecuteOutTranslatorNative( KUInt32 inInstruction )
 	switch (inInstruction & 0xFF)
 	{
 		default:
-			if (mLog)
+			if (LOG_OUT_TRANSLATOR)
 			{
 				mLog->FLogLine(
 					"Unknown out-translator native primitive %.8X (pc=%.8X)",
@@ -2242,21 +2267,21 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 	switch (inInstruction & 0xFF)
 	{
 		case 0x01:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::New" );
 			}
 			break;
 
 		case 0x02:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::Delete" );
 			}
 			break;
 
 		case 0x03:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::OpenLib" );
 			}
@@ -2265,7 +2290,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x04:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::CloseLib" );
 			}
@@ -2274,7 +2299,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x05:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::PrepareFFIStructure" );
 			}
@@ -2286,7 +2311,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x06:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::DisposeFFIStructure" );
 			}
@@ -2295,7 +2320,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x07:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::GetErrorMessage" );
 			}
@@ -2306,7 +2331,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x10:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_uint8" );
 			}
@@ -2319,7 +2344,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 
 
 		case 0x11:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_sint8" );
 			}
@@ -2331,7 +2356,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x12:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_uint16" );
 			}
@@ -2344,7 +2369,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 
 
 		case 0x13:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_sint16" );
 			}
@@ -2356,7 +2381,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x14:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_uint32" );
 			}
@@ -2369,7 +2394,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 
 
 		case 0x15:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_sint32" );
 			}
@@ -2381,7 +2406,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x16:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_uint64" );
 			}
@@ -2394,7 +2419,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 
 
 		case 0x17:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_sint64" );
 			}
@@ -2406,7 +2431,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x18:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_float" );
 			}
@@ -2418,7 +2443,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x19:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_double" );
 			}
@@ -2430,7 +2455,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x1A:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_longdouble" );
 			}
@@ -2442,7 +2467,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x1B:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_string" );
 			}
@@ -2459,7 +2484,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x1C:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_binary" );
 			}
@@ -2476,7 +2501,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x1D:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetArgValue_pointer" );
 			}
@@ -2488,7 +2513,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x20:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::SetResultType" );
 			}
@@ -2499,7 +2524,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x21:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::GetOutArgValue_string" );
 			}
@@ -2516,7 +2541,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x22:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::GetOutArgValue_binary" );
 			}
@@ -2533,7 +2558,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x30:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::Call_void" );
 			}
@@ -2543,27 +2568,27 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x31:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::Call_int" );
 			}
-			mProcessor->SetRegister(0, 
+			mProcessor->SetRegister(0,
 				mNativeCalls->Call_int(
 							mProcessor->GetRegister(1)));
 			break;
 
 		case 0x32:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::Call_real" );
 			}
-//			mProcessor->SetRegister(0, 
+//			mProcessor->SetRegister(0,
 //				mNativeCalls->Call_real(
 //							mProcessor->GetRegister(1)));
 			break;
 
 		case 0x33:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::Call_string" );
 			}
@@ -2575,7 +2600,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x34:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::Call_string" );
 			}
@@ -2585,7 +2610,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		case 0x40:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->LogLine( "TEinsteinNativeCalls::GetErrno" );
 			}
@@ -2593,7 +2618,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			break;
 
 		default:
-			if (mLog)
+			if (LOG_HOSTCALL)
 			{
 				mLog->FLogLine(
 					"Unknown call native primitive %.8X (pc=%.8X)",
@@ -2603,7 +2628,7 @@ TNativePrimitives::ExecuteHostCallNative( KUInt32 inInstruction )
 			mProcessor->SetRegister( 0, 0 );
 	}
 #else
-	if (mLog)
+	if (LOG_HOSTCALL)
 	{
 		mLog->FLogLine("Native primitives not supported on this platform");
 	}
@@ -2619,10 +2644,10 @@ TNativePrimitives::ExecuteNetworkManagerNative( KUInt32 inInstruction )
 	switch (inInstruction & 0xFF)
 	{
 			// Debugging Helpers
-			
+
 		case 0x00:
 			// Just log some unknown function without causing a fuss
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::Unknown" );
 			}
@@ -2643,67 +2668,67 @@ TNativePrimitives::ExecuteNetworkManagerNative( KUInt32 inInstruction )
 				mLog->LogLine(buffer);
 			}
 	        break; }
-			
+
 			// Protocol Class Interface
-			
+
 		case 0x02:
 			// a new driver is beeing created
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::New" );
 			}
 			break;
 		case 0x03:
 			// the driver is beeing deleted
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::Delete" );
 			}
 			break;
-			
+
 			// Task services
-			
+
 		case 0x04:
 			// Initialize the card driver
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::Init" );
 			}
 			break;
 		case 0x05:
 			// Enable the card (switch power on)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::Enable" );
 			}
 			break;
 		case 0x06:
 			// Disable the card (power off to save battery)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::Disable" );
 			}
 			break;
 		case 0x07:
 			// Handle any kind of interrupt by the hardware
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::InterruptHandler" );
 			}
 			break;
-			
+
 			// Client Services (from event handlers of TLanternDriverAPI)
-			
+
 		case 0x08:
 			// Newton transfers data to the world (calls SendPacket)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::SendBuffer" );
 			}
 			break;
 		case 0x09:
 			// Newton transfers data to the world (calls SendPacket)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::SendCBufferList" );
 			}
@@ -2712,7 +2737,7 @@ TNativePrimitives::ExecuteNetworkManagerNative( KUInt32 inInstruction )
 			// Newton wants to send a raw packet into the world
 			KUInt32 addr = mProcessor->GetRegister(1);
 			KUInt32 size = mProcessor->GetRegister(2), i;
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->FLogLine( "TNetworkManager::SendPacket(0x%08x, %d)", addr, size );
 			}
@@ -2731,7 +2756,7 @@ TNativePrimitives::ExecuteNetworkManagerNative( KUInt32 inInstruction )
 			KUInt32 dstBuffer = mProcessor->GetRegister(1);
 			KUInt32 dstBufferSize = mProcessor->GetRegister(2);
 			KUInt32 i, err = 0;
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->FLogLine( "TNetworkManager::GetDeviceAddress(0x%08x, %d)", dstBuffer, dstBufferSize );
 			}
@@ -2741,70 +2766,70 @@ TNativePrimitives::ExecuteNetworkManagerNative( KUInt32 inInstruction )
 				for (i=0; i<dstBufferSize; i++)
 					mMemory->WriteB(dstBuffer+i, mac[i]);
 			}
-			mProcessor->SetRegister(0, err);			
+			mProcessor->SetRegister(0, err);
 			break; }
 		case 0x0c:
 			// NewtonOS wants to add a multicast address (not implemented)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::AddMulticastAddress" );
 			}
 			break;
 		case 0x0d:
 			// NewtonOS wants to remove a multicast address (not implemented)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::DelMulticastAddress" );
 			}
 			break;
 		case 0x0e:
 			// NewtonOS wants to know if the links are OK  (not implemented)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::GetLinkIntegrity" );
 			}
 			break;
-			
+
 			// Optional services
-			
+
 		case 0x0f:
 			// receive every packet on the network, even those that are not meant for us (not implemented)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::SetPromiscuous" );
 			}
 			break;
 		case 0x10:
 			// return some number that gives the actual speed of the connection (not implemented)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::GetThroughput" );
 			}
 			break;
-			
+
 			// Private Template Services
-			
+
 		case 0x11:
 			// a regular timer that can help us poll data and monitor integrity and throughput
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				//mLog->LogLine( "TNetworkManager::TimerExpired" );
 			}
 			mNetworkManager->TimerExpired();
 			break;
-			
+
 			// NE2000 Template driver specific
-			
+
 		case 0x12:
 			// Initialize card (not needed?!)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::InitCard" );
 			}
 			break;
 		case 0x13:
 			// Set the card info (not needed?!)
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->LogLine( "TNetworkManager::SetCardInfo" );
 			}
@@ -2816,17 +2841,17 @@ TNativePrimitives::ExecuteNetworkManagerNative( KUInt32 inInstruction )
 				size = mNetworkManager->DataAvailable();
 			}
 			mProcessor->SetRegister(0, size);
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
                 if (size>0)
 					mLog->FLogLine( "TNetworkManager::DataAvailable(Avail: %d)", size );
 			}
 			break; }
-		case 0x15: { 
+		case 0x15: {
 			// Copy the next available packet into the buffer pointed to by R1
 			KUInt32 dst = mProcessor->GetRegister(1);
 			KUInt32 i, n = mProcessor->GetRegister(2);
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->FLogLine( "TNetworkManager::ReceiveData (buffer=0x%08x, size=%d", dst, n );
 			}
@@ -2853,15 +2878,15 @@ TNativePrimitives::ExecuteNetworkManagerNative( KUInt32 inInstruction )
 				mNetworkManager->LogBuffer(buffer, size);
 			}
 	        break; }
-			
+
 		default:
-			if (mLog)
+			if (LOG_NETWORKMANAGER)
 			{
 				mLog->FLogLine(
 							   "TNetworkManager: Unknown native primitive %.8X (pc=%.8X)",
 							   (unsigned int) inInstruction,
 							   (unsigned int) mProcessor->GetRegister(15) );
-			}					
+			}
 	}
 }
 
@@ -2872,7 +2897,7 @@ TNativePrimitives::ExecuteHostiOSNativeiOS( KUInt32 inInstruction )
 	switch (inInstruction & 0xFF)
 	{
 		case 0x01:
-			if (mLog)
+			if (LOG_HOSTIOS_NATIVEIOS)
 			{
 				mLog->LogLine( "TObjCBridgeCalls::HostGetCPUArchitecture" );
 			}
@@ -2880,7 +2905,7 @@ TNativePrimitives::ExecuteHostiOSNativeiOS( KUInt32 inInstruction )
 			mProcessor->SetRegister(0, mObjCBridgeCalls->HostGetCPUArchitecture());
 			break;
 		case 0x02:
-			if (mLog)
+			if (LOG_HOSTIOS_NATIVEIOS)
 			{
 				mLog->LogLine( "TObjCBridgeCalls::HostMakeNSInvocation" );
 			}
@@ -2890,7 +2915,7 @@ TNativePrimitives::ExecuteHostiOSNativeiOS( KUInt32 inInstruction )
 																		   mProcessor->GetRegister(2)));
 			break;
 		case 0x03:
-			if (mLog)
+			if (LOG_HOSTIOS_NATIVEIOS)
 			{
 				mLog->LogLine( "TObjCBridgeCalls::HostSetInvocationTarget" );
 			}
@@ -2899,7 +2924,7 @@ TNativePrimitives::ExecuteHostiOSNativeiOS( KUInt32 inInstruction )
 																			  mProcessor->GetRegister(1)));
 			break;
 		case 0x04:
-			if (mLog)
+			if (LOG_HOSTIOS_NATIVEIOS)
 			{
 				mLog->LogLine( "TObjCBridgeCalls::HostSetInvocationArgument_Object" );
 			}
@@ -2907,7 +2932,7 @@ TNativePrimitives::ExecuteHostiOSNativeiOS( KUInt32 inInstruction )
 									mObjCBridgeCalls->HostSetInvocationArgument_Object(mProcessor->GetRegister(0), mProcessor->GetRegister(1), mProcessor->GetRegister(2)));
 			break;
 		case 0x05:
-			if (mLog)
+			if (LOG_HOSTIOS_NATIVEIOS)
 			{
 				mLog->LogLine( "TObjCBridgeCalls::HostGetInvocationReturn_Object" );
 			}
@@ -2915,7 +2940,7 @@ TNativePrimitives::ExecuteHostiOSNativeiOS( KUInt32 inInstruction )
 									mObjCBridgeCalls->HostGetInvocationReturn_Object(mProcessor->GetRegister(0), mProcessor->GetRegister(1)));
 			break;
 		case 0x06:
-			if (mLog)
+			if (LOG_HOSTIOS_NATIVEIOS)
 			{
 				mLog->LogLine( "TObjCBridgeCalls::HostInvoke" );
 			}
@@ -2923,7 +2948,7 @@ TNativePrimitives::ExecuteHostiOSNativeiOS( KUInt32 inInstruction )
 									mObjCBridgeCalls->HostInvoke(mProcessor->GetRegister(0)));
 			break;
 		case 0x07:
-			if (mLog)
+			if (LOG_HOSTIOS_NATIVEIOS)
 			{
 				mLog->LogLine( "TObjCBridgeCalls::HostReleaseObject" );
 			}
@@ -2931,7 +2956,7 @@ TNativePrimitives::ExecuteHostiOSNativeiOS( KUInt32 inInstruction )
 									mObjCBridgeCalls->HostReleaseObject(mProcessor->GetRegister(0)));
 			break;
 		case 0x08:
-			if (mLog)
+			if (LOG_HOSTIOS_NATIVEIOS)
 			{
 				mLog->LogLine( "TObjCBridgeCalls::HostMakeNSString" );
 			}
@@ -2940,8 +2965,8 @@ TNativePrimitives::ExecuteHostiOSNativeiOS( KUInt32 inInstruction )
 																	   mProcessor->GetRegister(1)));
 			break;
 
-			
-			
+
+
 	}
 }
 #endif

--- a/Emulator/TNativePrimitives.h
+++ b/Emulator/TNativePrimitives.h
@@ -226,6 +226,7 @@ private:
 	/// \name Variables
 	TARMProcessor*		mProcessor;			///< Reference to the CPU.
 	TLog*				mLog;				///< Interface for logging.
+	KUInt32				mLogMask;			///< Bitmask for enabled logs
 	TMemory*			mMemory;			///< Interface to the memory.
 	TEmulator*			mEmulator;			///< Emulator (interface to hardware).
 	TNetworkManager*	mNetworkManager;	///< Network manager.


### PR DESCRIPTION
Use a bit field to enable or disable logging of native calls by subsystem. Leave the compile time enabling or disabling of logging for the flash subsystem in place for performance reasons