### PR TITLE
Add CI build for Ubuntu

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,46 @@
+name: CI on Linux
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get dependencies
+      run: sudo apt-get install -y libpulse-dev ninja-build
+    - name: Get sources
+      uses: actions/checkout@v2
+    - name: Get FLTK
+      uses: actions/checkout@v2
+      with:
+        repository: fltk/fltk
+        path: fltk
+    - name: Get newt64
+      uses: actions/checkout@v2
+      with:
+        repository: MatthiasWM/NEWT64
+        path: newt64
+    - name: Compile FLTK
+      run: |
+        cmake -S fltk -B fltk/build -D OPTION_USE_SYSTEM_LIBJPEG=Off \
+                       -D OPTION_USE_SYSTEM_ZLIB=Off \
+                       -D OPTION_USE_SYSTEM_LIBPNG=Off
+        cmake --build fltk/build
+        sudo cmake --install fltk/build
+    - name: Compile newt64
+      run: |
+        cmake -S newt64 -B newt64/build
+        cmake --build newt64/build
+        sudo cmake --install newt64/build
+    - name: Compile Einstein
+      run: |
+        cmake -S . -B _Build_/Makefiles
+        cmake --build _Build_/Makefiles

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # FLTK as its cross-platform GUI for all three desktop platforms.
 #
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.13)
 
 project("Einstein" VERSION "2020.4.13")
 

--- a/Toolkit/TFLScriptPanel.cpp
+++ b/Toolkit/TFLScriptPanel.cpp
@@ -27,6 +27,7 @@
 #include "TTkScript.h"
 
 #include <ctype.h>
+#include <cstdlib>
 
 
 // MARK: - TFLScriptPanel -

--- a/Toolkit/TFLTerminalPanel.cpp
+++ b/Toolkit/TFLTerminalPanel.cpp
@@ -22,6 +22,8 @@
 // ==============================
 
 
+#include <cstdlib>
+
 #include "Toolkit/TFLTerminalPanel.h"
 #include "Toolkit/TToolkit.h"
 

--- a/Toolkit/TTkScript.cpp
+++ b/Toolkit/TTkScript.cpp
@@ -22,6 +22,8 @@
 // ==============================
 
 
+#include <cstdlib>
+
 #include "TTkScript.h"
 
 #include "TToolkit.h"

--- a/Toolkit/TToolkit.cpp
+++ b/Toolkit/TToolkit.cpp
@@ -73,7 +73,7 @@ extern "C" {
 #include <FL/Fl_File_Chooser.H>
 
 #include <errno.h>
-
+#include <cstdlib>
 
 Fl_Text_Buffer *gTerminalBuffer = nullptr;
 


### PR DESCRIPTION
- Enable LGTM build with lower CMake version
- Remove linkage to fltk_z as that does not seem to exist in latest FLTK
  binaries