### PR TITLE
Better handling of FLTK version issues.

### DIFF
--- a/.github/workflows/macos_fltk.yml
+++ b/.github/workflows/macos_fltk.yml
@@ -36,8 +36,6 @@ jobs:
                       -D OPTION_USE_GL=Off
         cmake --build fltk/build
         sudo cmake --install fltk/build
-        # FIXME: this must be fixed in FLTK installation
-        sudo ln -f -s /usr/local/bin/fluid.app/Contents/MacOS/fluid /usr/local/bin/fluid
     - name: Compile newt64
       run: |
         cmake -S newt64 -B newt64/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 
 	# how to compile and link
 	target_compile_options(Einstein PUBLIC -Wall)
+#	target_compile_options(Einstein PUBLIC -Wall -Wextra -Wpedantic -Werror)
 	target_compile_definitions(Einstein PRIVATE TARGET_UI_FLTK=1 NO_PORT_AUDIO NO_X11 TARGET_OS_OPENSTEP=1 TARGET_OS_MAC=1 NS_BLOCK_ASSERTIONS=1)
 	target_link_libraries(Einstein
 		# /usr/local/lib/libfltk.a

--- a/Emulator/Screen/TFLScreenManager.cpp
+++ b/Emulator/Screen/TFLScreenManager.cpp
@@ -2,7 +2,7 @@
 // File:			TFLScreenManager.cp
 // Project:			Einstein
 //
-// Copyright 2003-2007 by Paul Guyot (pguyot@kallisys.net).
+// Copyright 2003-2022 by Paul Guyot (pguyot@kallisys.net).
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -261,14 +261,8 @@ public:
                 // more in FLTK. It would be preferable to find an
                 // accelerated GPU version or disable scaling.
                 Fl_RGB_Image img(rgbData_, rgbWidth_, rgbHeight_, 3);
-#if (FL_API_VERSION<10400)
-                Fl_Image *scaledImg = img.copy(w(), h());
-                scaledImg->draw(x(), y(), w(), h());
-                delete scaledImg;
-#else
                 img.scale(w(), h(), 0, 1);
                 img.draw(x(), y(), w(), h());
-#endif
             }
 #endif
         } else {

--- a/app/TFLApp.h
+++ b/app/TFLApp.h
@@ -2,7 +2,7 @@
 // File:			TFLApp.h
 // Project:			Einstein
 //
-// Copyright 2003-2020 by Paul Guyot and Matthias Melcher.
+// Copyright 2003-2022 by Paul Guyot and Matthias Melcher.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -23,6 +23,11 @@
 
 #ifndef _TFLAPP_H
 #define _TFLAPP_H
+
+#include <FL/Enumerations.H>
+#if (FL_API_VERSION<10400)
+# error Einstein for FLTK requires FLTK 1.4.0 or higher to compile.
+#endif
 
 #include <K/Defines/KDefinitions.h>
 

--- a/app/Version.h
+++ b/app/Version.h
@@ -2,7 +2,7 @@
 // File:			TCLIApp.h
 // Project:			Einstein
 //
-// Copyright 2003-2020 by Paul Guyot (pguyot@kallisys.net).
+// Copyright 2003-2022 by Paul Guyot (pguyot@kallisys.net).
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -30,9 +30,9 @@
 #define PROJECT_VER_MINOR "4"
 #define PROJECT_VER_PATCH "13"
 
-#define COMPILE_TIME_YYYY 2021
-#define COMPILE_TIME_MM (112-100)  // if the month is "09", C++ would interprete the number as octal, so we generate "109-100" instead.
-#define COMPILE_TIME_DD (130-100)
+#define COMPILE_TIME_YYYY 2022
+#define COMPILE_TIME_MM (101-100)  // if the month is "09", C++ would interprete the number as octal, so we generate "109-100" instead.
+#define COMPILE_TIME_DD (101-100)
 
 #define VERSION_STRING		PROJECT_NAME " " PROJECT_VER
 #define VERSION_STRING_SHORT	PROJECT_VER


### PR DESCRIPTION
The first included header should now complain if the FLTK version is too low.
The FLTK CI on macOS should no longer need the Fluid UI designer hack.