### PR TITLE
Add Debugger and DebugStr patches

### DIFF
--- a/Emulator/TEmulator.h
+++ b/Emulator/TEmulator.h
@@ -347,6 +347,16 @@ public:
 		}
 
 	///
+	/// Accessor on the logger
+	///
+	/// \return a pointer to the logger instance.
+	///
+	TLog*  GetLog( void )
+		{
+			return mLog;
+		}
+
+	///
 	/// Pause system and wait for next interrupt.
 	///
 	inline void	PauseSystem( void )


### PR DESCRIPTION
Allow native code to break in the monitor and log to stdout. The PC
adjustments in the patches take the jumptable calls into account.

stdout was chosen so that native modules can log without a special Einstein build.

The way PC is adjusted in the patches looks a bit strange. It does work, but the PR would definitely be good to check for this. Debug and DebugStr are unfortunately located in the ROM in a way that replacing more native code will not work.

Being able to patch the jump table might make this look better, but it seems that `TJITGenericPatchObject` does not allow patching these.

Anyway, ideas how to improve this PR are welcome :) It works, but could maybe be done better.