### PR TITLE
Use separate log for the monitor

### DIFF
--- a/app/FLTK/TFLApp.cpp
+++ b/app/FLTK/TFLApp.cpp
@@ -289,6 +289,7 @@ TFLApp::~TFLApp( void )
     delete mSoundManager;
     delete mNetworkManager;
     delete mLog;
+    delete mMonitorLog;
     delete mROMImage;
     delete mMonitor;
     delete mSymbolList;
@@ -312,24 +313,6 @@ TFLApp::Run( int argc, char* argv[] )
     InitFLTK(argc, argv);
 
     InitSettings();
-
-#if 1
-    TBufferLog *bl = new TBufferLog();
-#   if !NDEBUG
-#       if TARGET_OS_WIN32
-            bl->OpenLog("C:/user/micro/Einstein_log.txt");
-#       endif
-#       if TARGET_OS_MAC
-            bl->OpenLog("/tmp/Einstein_log.txt");
-#       endif
-#       if TARGET_OS_LINUX
-            bl->OpenLog("/tmp/Einstein_log.txt");
-#       endif
-#   endif
-    mLog = bl;
-#else
-    mLog = bl;
-#endif
 
     int ramSize = mFLSettings->RAMSize;
     Boolean hidemouse = (Boolean)mFLSettings->hideMouse;
@@ -1195,11 +1178,24 @@ void TFLApp::MountPCCardsKeptInSlot()
 
 void TFLApp::InitMonitor(const char *theROMImagePath)
 {
+    mMonitorLog = new TBufferLog();
+#   if !NDEBUG
+#       if TARGET_OS_WIN32
+            mMonitorLog->OpenLog("C:/user/micro/Einstein_log.txt");
+#       endif
+#       if TARGET_OS_MAC
+            mMonitorLog->OpenLog("/tmp/Einstein_log.txt");
+#       endif
+#       if TARGET_OS_LINUX
+            mMonitorLog->OpenLog("/tmp/Einstein_log.txt");
+#       endif
+#   endif
+
     char theSymbolListPath[FL_PATH_MAX];
     strncpy(theSymbolListPath, theROMImagePath, FL_PATH_MAX);
     fl_filename_setext(theSymbolListPath, FL_PATH_MAX, ".symbols");
     mSymbolList = new TSymbolList(theSymbolListPath);
-    mMonitor = new TFLMonitor((TBufferLog*)mLog, mEmulator, mSymbolList, theROMImagePath);
+    mMonitor = new TFLMonitor(mMonitorLog, mEmulator, mSymbolList, theROMImagePath);
     KPrintf("Booting... (Monitor enabled)\n");
 }
 

--- a/app/FLTK/TFLApp.h
+++ b/app/FLTK/TFLApp.h
@@ -45,6 +45,7 @@ class TEmulator;
 class TSoundManager;
 class TScreenManager;
 class TLog;
+class TBufferLog;
 class TPlatformManager;
 class TNetworkManager;
 class TMonitor;
@@ -213,6 +214,7 @@ private:
     TPlatformManager*	mPlatformManager = nullptr;
     TNetworkManager*	mNetworkManager = nullptr;
     TLog*				mLog = nullptr;
+    TBufferLog*			mMonitorLog = nullptr;
     TMonitor*			mMonitor = nullptr;
     TSymbolList*		mSymbolList = nullptr;
     TFLSettingsUI*      mFLSettings = nullptr;


### PR DESCRIPTION
Aligning the FLTP with the Mac app and using a separate log for the
monitor. Removing the explicit cast to TBufferLog which caused garbage
lines to be printed in the monitor if e.g. a TStdOutLog was used for the
application.