### PR TITLE
Windows command line build.

### DIFF
--- a/.github/workflows/mswindows.yml
+++ b/.github/workflows/mswindows.yml
@@ -28,13 +28,7 @@ jobs:
         path: newt64
     - name: Compile FLTK
       run: |
-        cmake -S fltk -B fltk/build \
-                      -D OPTION_USE_SYSTEM_LIBJPEG=Off \
-                      -D OPTION_USE_SYSTEM_ZLIB=Off \
-                      -D OPTION_USE_SYSTEM_LIBPNG=Off \
-                      -D FLTK_BUILD_TEST=Off \
-                      -D CMAKE_BUILD_TYPE=Release \
-                      -D OPTION_USE_GL=Off
+        cmake -S fltk -B fltk/build -D OPTION_USE_SYSTEM_LIBJPEG=Off -D OPTION_USE_SYSTEM_ZLIB=Off -D OPTION_USE_SYSTEM_LIBPNG=Off -D FLTK_BUILD_TEST=Off -D CMAKE_BUILD_TYPE=Release -D OPTION_USE_GL=Off
         cmake --build fltk/build --config Release
     - name: Compile newt64
       run: |

--- a/.github/workflows/mswindows.yml
+++ b/.github/workflows/mswindows.yml
@@ -1,0 +1,49 @@
+name: CI on Windows with FLTK
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Get sources
+      uses: actions/checkout@v2
+    - name: Get FLTK
+      uses: actions/checkout@v2
+      with:
+        repository: fltk/fltk
+        path: fltk
+    - name: Get newt64
+      uses: actions/checkout@v2
+      with:
+        repository: MatthiasWM/NEWT64
+        path: newt64
+    - name: Compile FLTK
+      run: |
+        cmake -S fltk -B fltk/build \
+                      -D OPTION_USE_SYSTEM_LIBJPEG=Off \
+                      -D OPTION_USE_SYSTEM_ZLIB=Off \
+                      -D OPTION_USE_SYSTEM_LIBPNG=Off \
+                      -D FLTK_BUILD_TEST=Off \
+                      -D CMAKE_BUILD_TYPE=Release \
+                      -D OPTION_USE_GL=Off
+        cmake --build fltk/build --config Release
+    - name: Compile newt64
+      run: |
+        cmake -S newt64 -B newt64/build -D CMAKE_BUILD_TYPE=Release
+        cmake --build newt64/build --config Release
+    - name: Compile Einstein
+      run: |
+        cmake -S . -B _Build_/Makefiles -D CMAKE_BUILD_TYPE=Release
+        cmake --build _Build_/Makefiles --config Release
+    - name: Run tests
+      run: |
+        _Build_/Makefiles/Release/EinsteinTests

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -382,4 +382,22 @@ running on iPhone 13 Max Pro with iOS 15.2
 
 
 
+Build log Window 11 and VisualStudin 2022
+
+Open a Developer COmmand Promt (Start Menu -> All Apps -> Visual Studi 2020 Folder -> Developer Command Promt for VS 2022)
+
+git clone https://github.com/pguyot/Einstein.git
+cd Einstein
+git clone https://github.com/fltk/fltk.git
+cmake -S fltk -B fltk/build -D OPTION_USE_SYSTEM_LIBJPEG=Off -D OPTION_USE_SYSTEM_ZLIB=Off -D OPTION_USE_SYSTEM_LIBPNG=Off -D CMAKE_BUILD_TYPE=Release -D OPTION_USE_GL=Off -D FLTK_BUILD_TEST=Off
+cmake --build fltk/build --config Release
+git clone https://github.com/MatthiasWM/NEWT64.git newt64
+cmake -S newt64 -B newt64/build -D CMAKE_BUILD_TYPE=Release
+# ignore warning
+cmake --build newt64/build --config Release
+cmake -S . -B build -D CMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+build\Release\Einstein.exe
+
+
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,7 +5,7 @@
 * Building Einstein with Cocoa on macOS in 64 bit with Xcode
 * Building Einstein with FLTK on macOS in 64 bit with Xcode
 * Building Einstein on Linux in 64 bit
-* Building Einstein on Windows 10
+* Building Einstein on Windows 10/11
 * Buidling Einstein for Android
 * Building Einstein for iOS
 
@@ -266,7 +266,7 @@ make
 ```
 
 
-## Building Einstein on Windows 11
+## Building Einstein on Windows 10/11
 
 ### Prerequisites
 
@@ -281,7 +281,7 @@ Prompt:
 ```
 Start Menu
   -> All Apps
-    -> Visual Studi 2020 Folder
+    -> Visual Studio 2020 Folder
       -> Developer Command Promt for VS 2022
 ```
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -16,15 +16,15 @@ Tested on macOS 10.15.3 Catalina with Xcode 11.4.
 
 Install Xcode from the Apple AppStore.
 
-Building Einstein with Cocoa is very easy and straight forward. Cocoa is the 
-user interface that is built into MacOS. Just open the 
+Building Einstein with Cocoa is very easy and straight forward. Cocoa is the
+user interface that is built into MacOS. Just open the
 ```_Build_/Xcode/Einstein.xcodeproj``` in Xcode and press Cmd-R to
 build and run the package. Einstein should launch in Debug mode
 after a few minutes and ask you for the location of the ROM.
 
 Einstein with Cocoa comes with network and serial port emulation,
 and an assembly language Monitor. If you are interested in
-emulating PCMCIA Flash Memory cards, or would like to try 
+emulating PCMCIA Flash Memory cards, or would like to try
 some programming in NewtonScript, Einstein with FLTK is the better choice.
 
 
@@ -63,7 +63,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -D FLTK_BUILD_TEST=Off \
       ../..
 # -- Build FLTK
-make 
+make
 # -- Install the FLTK library, includes, and tools
 sudo make install
 cd ../../..
@@ -71,10 +71,10 @@ cd ../../..
 
 ### Newt64/Toolkit
 
-Newt64 will enable the built-in Developer Toolkit in Einstein 
+Newt64 will enable the built-in Developer Toolkit in Einstein
 and a few other features that depend on NewtonScript compilation features.
 
-Clone the Git repository in https://github.com/MatthiasWM/NEWT64.git, 
+Clone the Git repository in https://github.com/MatthiasWM/NEWT64.git,
 build the library with *CMake*, and copy it to ```/usr/local/lib/libnewt64.s```
 Also, copy all files in ```.../src/newt_core/incs/``` into ```/usr/local/include/newt64/```.
 
@@ -137,11 +137,11 @@ cd ../../..
 In Xcode, select `Product > Run` from the main menu or type `Apple-R` to compile and run Einstein
 in debugging mode.
 
-To generate the faster release version, select `Product > Archive` to create an optimized version. 
+To generate the faster release version, select `Product > Archive` to create an optimized version.
 This takes a few minutes, but eventually Xcode will show you a dialog box with the archive that you just created.
 
 Right-click on the little icon and select `Show in Finder`. Then in Finder, right-click
-on the archive again and choose `Show Package Contents`. You will find the fast version 
+on the archive again and choose `Show Package Contents`. You will find the fast version
 of Einstein inside the folder `Products > Application`.
 
 Continue with setting up the ROM as described in the manual. Enjoy.
@@ -167,7 +167,7 @@ Install Clang, Make, and CMake. CMake may ask for more resources in the process.
 them with `sudo apt-get install ...`.
 
 ```bash
-sudo apt-get install git cmake 
+sudo apt-get install git cmake
 sudo apt-get install clang
 sudo apt-get install autoconf
 sudo apt-get install libx11-dev
@@ -202,7 +202,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -D FLTK_BUILD_TEST=Off \
       ../..
 # -- Build FLTK
-make 
+make
 # -- Install the FLTK library, includes, and tools
 sudo make install
 cd ../../..
@@ -210,7 +210,7 @@ cd ../../..
 
 ### Newt64/Toolkit
 
-Newt64 will enable the built-in Developer Toolkit in Einstein 
+Newt64 will enable the built-in Developer Toolkit in Einstein
 and a few other features that depend on NewtonScript compilation features.
 
 ```bash
@@ -228,7 +228,7 @@ sudo make install
 cd ../..
 ```
 
-### Einstein 
+### Einstein
 
 Then download and build Einstein:
 
@@ -270,20 +270,20 @@ make
 
 ### Prerequisites
 
-Install VisualStudio 2020. It will include the C++ compiler. Make sure that 
+Install VisualStudio 2020. It will include the C++ compiler. Make sure that
 the CMake tools are also installed.
 
-You will also need git. You can install it 
-from this source: https://gitforwindows.org . 
+You will also need git. You can install it
+from this source: https://gitforwindows.org .
 
 Einstein can built very easily from the command line. Open the Developer Command
 Prompt:
 ```
-Start Menu 
-  -> All Apps 
-    -> Visual Studi 2020 Folder 
+Start Menu
+  -> All Apps
+    -> Visual Studi 2020 Folder
       -> Developer Command Promt for VS 2022
-```      
+```
 
 Enter the following commands into the shell.
 
@@ -293,14 +293,14 @@ git clone https://github.com/pguyot/Einstein.git
 cd Einstein
 ```
 Download and build FLTK inside the Einstein folder. FLTK is a cross-platform
-user interface toolkit. FLTK is not optional. 
+user interface toolkit. FLTK is not optional.
 ```
 git clone https://github.com/fltk/fltk.git
 cmake -S fltk -B fltk/build -D OPTION_USE_SYSTEM_LIBJPEG=Off -D OPTION_USE_SYSTEM_ZLIB=Off -D OPTION_USE_SYSTEM_LIBPNG=Off -D CMAKE_BUILD_TYPE=Release -D OPTION_USE_GL=Off -D FLTK_BUILD_TEST=Off
 cmake --build fltk/build --config Release
 ```
 Download and build Newt64 inside the Einstein folder. Newt64 is a NewtonScript
-interpreter and is the basis of the built-in Toolkit. Newt64 is optional. 
+interpreter and is the basis of the built-in Toolkit. Newt64 is optional.
 ```
 git clone https://github.com/MatthiasWM/NEWT64.git newt64
 cmake -S newt64 -B newt64/build -D CMAKE_BUILD_TYPE=Release
@@ -332,7 +332,7 @@ The ```_Build_``` folder contains the current setup for Einstein on Android. Ope
 Android Studio and launch the project in the ```_Build_/AndroidStudioNative```.
 
 The Android version of EInstein is still in its Alpha stage and will need
-some more development before it is actually usable.  
+some more development before it is actually usable.
 
 Note that changes in the source tree are sometimes not propageted
 to the Android build for a while.
@@ -340,7 +340,7 @@ to the Android build for a while.
 
 ## Building Einstein for iOS
 
-Tested on Dec 27 2021, compiled 12.0.1 Monterey and M1 CPU, 
+Tested on Dec 27 2021, compiled 12.0.1 Monterey and M1 CPU,
 running on iPhone 13 Max Pro with iOS 15.2
 
  - install the Xcode developer environment from teh Apple AppStore, it's free

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -266,82 +266,56 @@ make
 ```
 
 
-## Building Einstein on Windows 10
+## Building Einstein on Windows 11
 
 ### Prerequisites
 
-Install VisualStudio 2019 with the C++ compiler, CMake, and Git components. 
-I like to install TortoiseGIT as well to make accessing GitHub easy.
+Install VisualStudio 2020. It will include the C++ compiler. Make sure that 
+the CMake tools are also installed.
 
-### FLTK 
+You will also need git. You can install it 
+from this source: https://gitforwindows.org . 
 
-Download, build, and install FLTK first. FLTK is a cross-platform user interface library
-that is easy to use and very light on resources. See https://www.fltk.org .
-
-Clone `https://github.com/fltk/fltk.git` into a directory named `fltk`.
-
-Add the following lines to the beginning of `fltk/CMakeListst.txt`:
+Einstein can built very easily from the command line. Open the Developer Command
+Prompt:
 ```
-cmake_minimum_required(VERSION 3.15)
-cmake_policy(SET CMP0091 NEW)
-set (CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+Start Menu 
+  -> All Apps 
+    -> Visual Studi 2020 Folder 
+      -> Developer Command Promt for VS 2022
+```      
+
+Enter the following commands into the shell.
+
+Downlaod the Einstein source code:
 ```
-
-Launch VisualStudio 2019. Click on "Continue without code...". An 
-empty project will open. Select `File > Open > CMake...` from the VisualStudio
-main menu and select `CMakeLists.txt` in the fltk root directory.
-
-Add a Release target if VC did not already create it. Then build and run `fluid.exe`
-in x64-Release mode to verify that FLTK built fine.
-
-Next, chose `Project > CMake settings for FLTK` from the main menu. Scroll down
-in the settings window and find the entry for `CMAKE_INSTALL_PREFIX`. Copy
-the path. We will need it later. In my case, it was `C:\Users\micro\dev\fltk-1.4 for Einstein.git\out\install\x64-Release`,
-but it will be diffferent on your machine.
-
-Install FLTK by choosing `Build > Install FLTK`.
-
-For Einstein to find FLTK, we need to create a link in the file system. Open
-a Command Prompt in Administrator mode and type the following commands, but replace
-the last path with whatever your FLTK path is.
-
+git clone https://github.com/pguyot/Einstein.git
+cd Einstein
 ```
-c:
-cd "c:\Program Files"
-mklink /D FLTK "C:\Users\micro\dev\fltk-1.4 for Einstein.git\out\install\x64-Release"
+Download and build FLTK inside the Einstein folder. FLTK is a cross-platform
+user interface toolkit. FLTK is not optional. 
 ```
-
-### Newt64/Toolkit
-
-Newt64 will enable the built-in Developer Toolkit in Einstein 
-and a few other features that depend on NewtonScript compilation features.
-
-You need to install _flex_ and _bison_ in `C:/GnuWin32/` and add `C:/GnuWin32/bin` to the Path variable in the user environment settings.
-
-As of December 2020, both tools can be downloaded from `https://github.com/lexxmark/winflexbison/releases/tag/v2.5.23`, unpacked, and then
-copy the content of the archive into `C:/GnuWin32/bin`. Remove the *win_* prefix from *yacc.exe* and *bison.exe*. 
-Next, launch `Advanced System Settings` from the _Window 10_ Search Bar, click on
-`Environmet Variables...`, the edit the _PATH_ variable and add `C:/GnuWin32/bin`. Close all dialogs.
-
-Open Visual Studio and clone the GitHub project `https://github.com/MatthiasWM/NEWT64.git`.
-Add the `x64-Release` configuration. Newt64 should find all resources now. Build and install.
-
-
-### Einstein
-
-Next, download and build Einstein:
-
-Clone the Einstein source code from `https://github.com/pguyot/Einstein.git` into a folder named `Einstein`.
-
-Again, launch VisualStudio and click "Continue without code...", the select
-`File > Open > CMake...` from the VisualStudio
-main menu and select `CMakeLists.txt` in the Einstein root directory.
-
-VisualStudio should find all resources including FLTK and Fluid. Set Einstein
-as your startup project and compile and run the program.
-
+git clone https://github.com/fltk/fltk.git
+cmake -S fltk -B fltk/build -D OPTION_USE_SYSTEM_LIBJPEG=Off -D OPTION_USE_SYSTEM_ZLIB=Off -D OPTION_USE_SYSTEM_LIBPNG=Off -D CMAKE_BUILD_TYPE=Release -D OPTION_USE_GL=Off -D FLTK_BUILD_TEST=Off
+cmake --build fltk/build --config Release
+```
+Download and build Newt64 inside the Einstein folder. Newt64 is a NewtonScript
+interpreter and is the basis of the built-in Toolkit. Newt64 is optional. 
+```
+git clone https://github.com/MatthiasWM/NEWT64.git newt64
+cmake -S newt64 -B newt64/build -D CMAKE_BUILD_TYPE=Release
+cmake --build newt64/build --config Release
+```
+With all prerequisites installed, we can finally build Einstein:
+```
+cmake -S . -B build -D CMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+```
+If everything went well, Einstein can be found here:
+```
+build\Release\Einstein.exe
+```
 Continue with setting up the ROM as described in the manual. Enjoy.
-
 
 ### BasiliskII
 There is a version of the Macintosh Emulator BasiliskII for Windows that can connect directly

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,12 @@ if ( ${CMAKE_SYSTEM_NAME} STREQUAL "Windows" )
 	find_package( Newt64 CONFIG HINTS ${CMAKE_CURRENT_SOURCE_DIR}/newt64/build )
 endif()
 
-find_library( newt64_lib NAMES newt64 HINTS ${CMAKE_CURRENT_SOURCE_DIR}/newt64/build )
+find_library ( newt64_lib NAMES newt64
+	HINTS
+		${CMAKE_CURRENT_SOURCE_DIR}/newt64/build/Release
+		${CMAKE_CURRENT_SOURCE_DIR}/newt64/build/Debug
+		${CMAKE_CURRENT_SOURCE_DIR}/newt64/build
+)
 find_file( newt64_incl NAMES NewtCore.h PATH_SUFFIXES newt64 HINTS ${CMAKE_CURRENT_SOURCE_DIR}/newt64/src/newt_core/incs )
 
 if ( newt64_lib MATCHES ".*NOTFOUND" OR newt64_incl MATCHES ".*NOTFOUND" )
@@ -104,12 +109,19 @@ endif ()
 
 # TODO: update this to automatically download and build in .../Einstein/fltk
 set( FLTK_SKIP_OPENGL true )
-if ( WIN32 )
-	find_program( LOCAL_FLTK_FLUID_EXECUTABLE fluid HINTS ${CMAKE_SOURCE_DIR}/fltk/build/bin "C:/Program Files/FLTK/bin" )
-else ()
-	find_program( LOCAL_FLTK_FLUID_EXECUTABLE fluid HINTS ${CMAKE_SOURCE_DIR}/fltk/build/bin )
-endif ()
+find_program( LOCAL_FLTK_FLUID_EXECUTABLE fluid
+	HINTS
+		${CMAKE_SOURCE_DIR}/fltk/build/bin/Release
+		${CMAKE_SOURCE_DIR}/fltk/build/bin/Debug
+		${CMAKE_SOURCE_DIR}/fltk/build/bin
+)
 find_package( FLTK REQUIRED NO_MODULE HINTS ${CMAKE_SOURCE_DIR}/fltk/build )
+
+if ( ${LOCAL_FLTK_FLUID_EXECUTABLE} MATCHES ".*NOTFOUND" )
+	message( WARNING "Fluid (FLTK User Interface Designer) not found!" )
+else ()
+	message( STATUS "Fluid (FLTK User Interface Designer) found at " ${LOCAL_FLTK_FLUID_EXECUTABLE})
+endif ()
 
 function ( build_with_fluid name dir )
 	add_custom_command (
@@ -335,11 +347,12 @@ elseif ( WIN32 )
 		fltk_png
 		fltk_z
 		winmm
+		gdiplus
 	)
 	target_link_libraries ( EinsteinTests
 		${system_libs}
 		fltk
-		pthread
+		gdiplus
 	)
 
 endif ()

--- a/Monitor/TMonitor.cpp
+++ b/Monitor/TMonitor.cpp
@@ -21,6 +21,9 @@
 // $Id$
 // ==============================
 
+// Tell MSWindows to not generate a min/max macro
+#define NOMINMAX
+
 #include <K/Streams/TFileStream.h>
 #include "TMonitor.h"
 


### PR DESCRIPTION
This is a complete and tested build setup for MS Windows.

It's by far easier to build Einstein from the command line than describing every button click in the VisualStudio user interface. This setup will also build FLTK and Newt64 without the need to install either. The instructions will build in Release mode for Intel 64bit processors.