### PR TITLE
Automating binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,97 @@
-name: Testing manually triggered workflows
+#
+# This script will tag the repo, compile and zip Einstein, and publish it
+# as a GitHub Release
+#
+# see: https://github.com/marketplace/actions/publish-release
+#
+# Calling other workflows from this workflow:
+# https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
+
+
+name: Release Einstein on GitHub
 on:
   workflow_dispatch:
     inputs:
-      ae_version:
-        description: 'Version String'
+      version_tag:
+        description: 'Release Version Tag'
         required: true
-        default: '1.3.2b'
+        default: '2022.4.15'
+        # use CMake to updtae the default release version tag
+      build-macos-fltk-universal:
+        type: boolean
+        description: Build macOS Universal Binary
+        default: 'true'
+      #build-for-windows:
+      #  type: boolean
+      #  description: Build Win64 Intel Binary
+      #build-for-linux:
+      #  type: boolean
+      #  description: Build Linux Intel Binary
+
 jobs:
-  say_hello:
-    runs-on: ubuntu-latest
+  release-macos-fltk-universal:
+    runs-on: macos-latest
+    if: ${{ github.event.inputs.build-macos-fltk-universal == 'true' }}
     steps:
-      - run: |
-          echo "Hello ${{ github.event.inputs.name }}!"
-          echo "- in ${{ github.event.inputs.home }}!"jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-    - run: |
-          echo "Creating Einstein Test Release ${{ github.event.inputs.ae_version }}!"
-    - name: Create Draft Release
+    - name: Create Release
       id: create_release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: v20204.11
-        release_name: "TestRelease"
-        draft: true
+        tag_name: ${{ github.event.inputs.version_tag }}
+        release_name: "Version ${{ github.event.inputs.version_tag }}"
+        draft: false
         prerelease: false
-
+    - name: Get sources
+      uses: actions/checkout@v2
+    - name: Get FLTK
+      uses: actions/checkout@v2
+      with:
+        repository: fltk/fltk
+        path: fltk
+    - name: Get newt64
+      uses: actions/checkout@v2
+      with:
+        repository: MatthiasWM/NEWT64
+        path: newt64
+    - name: Compile FLTK
+      run: |
+        cmake -S fltk -B fltk/build \
+                      -D OPTION_USE_SYSTEM_LIBJPEG=Off \
+                      -D OPTION_USE_SYSTEM_ZLIB=Off \
+                      -D OPTION_USE_SYSTEM_LIBPNG=Off \
+                      -D FLTK_BUILD_TEST=Off \
+                      -D OPTION_USE_GL=Off
+        cmake --build fltk/build
+        sudo cmake --install fltk/build
+    - name: Compile newt64
+      run: |
+        cmake -S newt64 -B newt64/build
+        cmake --build newt64/build
+        sudo cmake --install newt64/build
+    - name: Configure Einstein
+      run: |
+        cmake -S . -B _Build_/Makefiles
+    - name: Compile Einstein
+      run: |
+        cmake --build _Build_/Makefiles
+    - name: Pack Einstein
+      run: |
+        cd _Build_/Makefiles
+        zip -9 Einstein_macOS_fltk_${{github.event.inputs.version_tag}}.zip Einstein.app
     - uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./README.md
-        asset_name: README.md
+        # upload this file
+        asset_path: ./spot.zip
+        # and give it that name in the destination
+        asset_name: spot.zip
         asset_content_type: application/zip
-
     - uses: eregon/publish-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         release_id: ${{ steps.create_release.outputs.id }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,50 +1,54 @@
 #
 # This script will tag the repo, compile and zip Einstein, and publish it
-# as a GitHub Release
+# as a GitHub Release.
 #
-# see: https://github.com/marketplace/actions/publish-release
-#
-# Calling other workflows from this workflow:
-# https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
 
 
-name: Release Einstein on GitHub
+name: 'Deploy Einstein on GitHub'
+
+# This job must be called explicitily form the 'Actions' tab in github
 on:
   workflow_dispatch:
     inputs:
-      version_tag:
-        description: 'Release Version Tag'
-        required: true
-        default: '2022.4.15'
-        # use CMake to updtae the default release version tag
-      build-macos-fltk-universal:
+      # The Version Tag is extracted from CMakeLists.txt
+      #version_tag:
+      #  description: 'Release Version Tag'
+      #  required: true
+      #  default: '2022.4.15'
+      build-macos-universal-fltk:
         type: boolean
-        description: Build macOS Universal Binary
+        description: Build macOS Universal FLTK
         default: 'true'
-      #build-for-windows:
-      #  type: boolean
-      #  description: Build Win64 Intel Binary
-      #build-for-linux:
-      #  type: boolean
-      #  description: Build Linux Intel Binary
+      build-linux-x64-fltk:
+        type: boolean
+        description: Build Linux x64 FLTK
+        default: 'true'
+      build-windows-x64-fltk:
+        type: boolean
+        description: Build Windows x64 FLTK
+        default: 'true'
+      build-macos-universal-cocoa:
+        type: boolean
+        description: Build macOS Universal Cocoa
+        default: 'true'
+      # build-windows-arm64-fltk:
+      # build-android
+      # build-iOS
 
 jobs:
-  release-macos-fltk-universal:
+
+  # Build the MacOS FLTK version as a Universal Binary for x64 and ARM64
+  build-macos-universal-fltk:
     runs-on: macos-latest
-    if: ${{ github.event.inputs.build-macos-fltk-universal == 'true' }}
+    if: ${{ github.event.inputs.build-macos-universal-fltk == 'true' }}
     steps:
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.event.inputs.version_tag }}
-        release_name: "Version ${{ github.event.inputs.version_tag }}"
-        draft: false
-        prerelease: false
-    - name: Get sources
+    - name: Get Einstein Sources
       uses: actions/checkout@v2
+    - name: Get Release Version Tag
+      run: |
+        export RELEASE_TAG="v"`grep -o '"Einstein" VERSION "[^"]*' CMakeLists.txt  | grep -o '[^"]*$'`
+        echo "RELEASE_TAG=$RELEASE_TAG"
+        echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
     - name: Get FLTK
       uses: actions/checkout@v2
       with:
@@ -62,36 +66,185 @@ jobs:
                       -D OPTION_USE_SYSTEM_ZLIB=Off \
                       -D OPTION_USE_SYSTEM_LIBPNG=Off \
                       -D FLTK_BUILD_TEST=Off \
-                      -D OPTION_USE_GL=Off
+                      -D OPTION_USE_GL=Off \
+                      -D CMAKE_BUILD_TYPE=Release \
+                      -D CMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+                      -D "CMAKE_OSX_ARCHITECTURES=arm64;x86_64"
         cmake --build fltk/build
-        sudo cmake --install fltk/build
     - name: Compile newt64
       run: |
-        cmake -S newt64 -B newt64/build
+        cmake -S newt64 -B newt64/build \
+                      -D CMAKE_BUILD_TYPE=Release \
+                      -D CMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+                      -D "CMAKE_OSX_ARCHITECTURES=arm64;x86_64"
         cmake --build newt64/build
-        sudo cmake --install newt64/build
-    - name: Configure Einstein
-      run: |
-        cmake -S . -B _Build_/Makefiles
     - name: Compile Einstein
       run: |
-        cmake --build _Build_/Makefiles
+        cmake -S . -B build \
+                      -D CMAKE_BUILD_TYPE=Release \
+                      -D CMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+                      -D "CMAKE_OSX_ARCHITECTURES=arm64;x86_64"
+        cmake --build build --target Einstein
     - name: Pack Einstein
       run: |
-        cd _Build_/Makefiles
-        zip -9 Einstein_macOS_fltk_${{github.event.inputs.version_tag}}.zip Einstein.app
-    - uses: actions/upload-release-asset@v1.0.1
+        mv build/Einstein.app .
+        cmake -E tar cf Einstein_macOS_universal_fltk_${{env.RELEASE_TAG}}.zip --format=zip Einstein.app
+    - name: Publish Einstein
+      uses: ncipollo/release-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        # upload this file
-        asset_path: ./spot.zip
-        # and give it that name in the destination
-        asset_name: spot.zip
-        asset_content_type: application/zip
-    - uses: eregon/publish-release@v1
+        allowUpdates: 'true'
+        artifacts: Einstein_macOS_universal_fltk_${{env.RELEASE_TAG}}.zip
+        artifactContentType: application/zip
+        bodyFile: ReleaseText.md
+        tag: ${{ env.RELEASE_TAG }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-linux-x64-fltk:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.build-linux-x64-fltk == 'true' }}
+    steps:
+    - name: Get dependencies
+      run: |
+        sudo apt-get install -y libpulse-dev ninja-build libbsd-dev
+        wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
+        sudo apt-get update
+        sudo apt-get install clang-format-13
+    - name: Get sources
+      uses: actions/checkout@v2
+    - name: Get Version
+      run: |
+        export RELEASE_TAG="v"`grep -o '"Einstein" VERSION "[^"]*' CMakeLists.txt  | grep -o '[^"]*$'`
+        echo "RELEASE_TAG=$RELEASE_TAG"
+        echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
+    - name: Get FLTK
+      uses: actions/checkout@v2
+      with:
+        repository: fltk/fltk
+        path: fltk
+    - name: Get newt64
+      uses: actions/checkout@v2
+      with:
+        repository: MatthiasWM/NEWT64
+        path: newt64
+    - name: Compile FLTK
+      run: |
+        cmake -S fltk -B fltk/build \
+                      -D OPTION_USE_SYSTEM_LIBJPEG=Off \
+                      -D OPTION_USE_SYSTEM_ZLIB=Off \
+                      -D OPTION_USE_SYSTEM_LIBPNG=Off \
+                      -D FLTK_BUILD_TEST=Off \
+                      -D OPTION_USE_GL=Off \
+                      -D CMAKE_BUILD_TYPE=Release
+        cmake --build fltk/build
+    - name: Compile newt64
+      run: |
+        cmake -S newt64 -B newt64/build \
+                      -D CMAKE_BUILD_TYPE=Release
+        cmake --build newt64/build
+    - name: Compile Einstein
+      run: |
+        cmake -S . -B build \
+                      -D CMAKE_BUILD_TYPE=Release
+        cmake --build build --target Einstein
+    - name: Pack Einstein
+      run: |
+        mv build/Einstein .
+        cmake -E tar cf Einstein_linux_x64_fltk_${{env.RELEASE_TAG}}.zip --format=zip Einstein
+    - name: Publish Einstein
+      uses: ncipollo/release-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        release_id: ${{ steps.create_release.outputs.id }}
+        allowUpdates: 'true'
+        artifacts: Einstein_linux_x64_fltk_${{env.RELEASE_TAG}}.zip
+        artifactContentType: application/zip
+        bodyFile: ReleaseText.md
+        tag: ${{ env.RELEASE_TAG }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-windows-x64-fltk:
+    runs-on: windows-latest
+    if: ${{ github.event.inputs.build-windows-x64-fltk == 'true' }}
+    steps:
+    - name: Get sources
+      uses: actions/checkout@v2
+    - name: Get Version
+      shell: pwsh
+      run: |
+        # Select-String -Path CMakeLists.txt -CaseSensitive -Pattern '"Einstein" VERSION'
+        $env:RELEASE_TAG2=(Select-String -Path CMakeLists.txt -CaseSensitive -Pattern '"Einstein" VERSION')
+        # gci env:RELEASE_TAG2
+        $env:RELEASE_TAG=($env:RELEASE_TAG2 -replace '.* VERSION "', '' -replace '".*\)', '')
+        # gci env:RELEASE_TAG
+        echo "RELEASE_TAG=v$env:RELEASE_TAG"
+        echo "RELEASE_TAG=v$env:RELEASE_TAG" >> $env:GITHUB_ENV
+    - name: Get FLTK
+      uses: actions/checkout@v2
+      with:
+        repository: fltk/fltk
+        path: fltk
+    - name: Get newt64
+      uses: actions/checkout@v2
+      with:
+        repository: MatthiasWM/NEWT64
+        path: newt64
+    - name: Compile FLTK
+      run: |
+        cmake -G "Visual Studio 16 2019" -S fltk -B fltk/build -A x64 -D OPTION_USE_SYSTEM_LIBJPEG=Off -D OPTION_USE_SYSTEM_ZLIB=Off -D OPTION_USE_SYSTEM_LIBPNG=Off -D FLTK_BUILD_TEST=Off -D OPTION_USE_GL=Off
+        cmake --build fltk/build --config Release
+    - name: Compile newt64
+      run: |
+        cmake -G "Visual Studio 16 2019" -S newt64 -B newt64/build -A x64
+        cmake --build newt64/build --config Release
+    - name: Compile Einstein
+      run: |
+        cmake -G "Visual Studio 16 2019" -S . -B build -A x64
+        cmake --build build --config Release --target Einstein
+    - name: Pack Einstein
+      run: |
+        mv build/Release/Einstein.exe .
+        cmake -E tar cf Einstein_windows_x64_fltk_${{env.RELEASE_TAG}}.zip --format=zip Einstein.exe
+    - uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: 'true'
+        artifacts: Einstein_windows_x64_fltk_${{env.RELEASE_TAG}}.zip
+        artifactContentType: application/zip
+        bodyFile: ReleaseText.md
+        tag: ${{ env.RELEASE_TAG }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos-universal-cocoa:
+    runs-on: macos-latest
+    if: ${{ github.event.inputs.build-macos-universal-cocoa == 'true' }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get Release Version Tag
+      run: |
+        export RELEASE_TAG="v"`grep -o '"Einstein" VERSION "[^"]*' CMakeLists.txt  | grep -o '[^"]*$'`
+        echo "RELEASE_TAG=$RELEASE_TAG"
+        echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
+    - name: Build
+      run: |
+        xcodebuild archive \
+          -project _Build_/Xcode/Einstein.xcodeproj \
+          -scheme Einstein -configuration Release \
+          -archivePath Einstein.xcarchive \
+          ONLY_ACTIVE_ARCH=NO
+    - name: Pack Einstein
+      run: |
+        mv Einstein.xcarchive/Products/Applications/Einstein.app .
+        cmake -E tar cf Einstein_macOS_universal_cocoa_${{env.RELEASE_TAG}}.zip --format=zip Einstein.app
+    - name: Publish Einstein
+      uses: ncipollo/release-action@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        allowUpdates: 'true'
+        artifacts: Einstein_macOS_universal_cocoa_${{env.RELEASE_TAG}}.zip
+        artifactContentType: application/zip
+        bodyFile: ReleaseText.md
+        tag: ${{ env.RELEASE_TAG }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Draft Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v20204.11
+        release_name: "TestRelease"
+        draft: true
+        prerelease: false
+
+    - uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./README.md
+        asset_name: README.md
+        asset_content_type: application/zip
+
+    - uses: eregon/publish-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        release_id: ${{ steps.create_release.outputs.id }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,23 @@
+name: Testing manually triggered workflows
+on:
+  workflow_dispatch:
+    inputs:
+      ae_version:
+        description: 'Version String'
+        required: true
+        default: '1.3.2b'
 jobs:
+  say_hello:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Hello ${{ github.event.inputs.name }}!"
+          echo "- in ${{ github.event.inputs.home }}!"jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+    - run: |
+          echo "Creating Einstein Test Release ${{ github.event.inputs.ae_version }}!"
     - name: Create Draft Release
       id: create_release
       uses: actions/create-release@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-project( "Einstein" VERSION "2022.5.0" )
+project( "Einstein" VERSION "2022.4.17" )
 
 # ---- Configuration for all targets on all platforms
 
@@ -282,7 +282,8 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
 	# how to compile and link
 	target_compile_options ( Einstein PUBLIC
 		-Wall -Wno-multichar -Wno-misleading-indentation
-		-Wno-missing-field-initializers -Werror
+		-Wno-missing-field-initializers # -Werror
+		# Werror is diesable for testing purposes. Must reenable as soon as all Linux warnings are fixed.
 	)
 	target_compile_options ( EinsteinTests PUBLIC
 		-Wall -Wno-multichar -Wno-misleading-indentation

--- a/ReleaseText.md
+++ b/ReleaseText.md
@@ -1,0 +1,39 @@
+
+Binary Release v2022.4.17
+=========================
+
+This is our first automated binary release for Einstein.
+
+Release 4.17 contains a few unfinished features for early 
+testing. After collecting user somments, a full featured
+set will be implemented in v2022.5.0.
+
+User Release Notes
+------------------
+ - Y10k problem is always fixed, time and date is set automatically
+ - Newtwork setup now emulates DHCP, many more network emulation fixes
+ - Added Credits and Licenses section to the About panel
+ - Added Essentials panel for easy install of common tools and apps
+ - print screenshots (FLTK)
+
+Developer Release Notes
+-----------------------
+ - serial port drivers changed internally
+ - many fixes to building, bug finding, and deployment
+ - many fixes to formatting and ease of maintenance
+ - REx can now compile on modern machines
+ - the REx is now part of the app (Cocoa)
+
+Releases come for different CPUs:
+ - x64 stands for Intel 64 bit CPUs
+ - arm64 binaries run on 64 bit ARM systems
+ - universal binaries run on Apple Intel and M1 Apple silicon
+
+Releases use different User Interface libraries:
+ - Cocoa is Paul's original version running on MacOS without additional software
+ - FLTK adds PCMCIA and Toolkit support and runs on all desktop platforms
+ - the Androis version uses NDK directly and is not yet part of this release yet
+ - due to restriction in the Apple Stroe, the iOS version needs to be built from source as explained in BUILDING.md 
+
+And as always, enjoy, and give us feedback, no matter if good or bad.
+


### PR DESCRIPTION
This adds a new entry in 'Actions' that can be used to generate binaries for all Desktop platforms. Mobile device deployment will be added later. The version tag is taken from the `"Einstein" VERSION "..."` line in `./CMakeLists.txt`. The Release text is taken form the file `./ReleaseText.md` and published with the binary release on GitHub.