### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+exclude: '^(libffi.*|portaudio)/'
+repos:
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v13.0.0'
+    hooks:
+    -   id: clang-format
+        files: '.*\.(h|cpp|t|mm|c)$'
+        exclude: '^(libffi.*|portaudio|Packages|Resources|Drivers)/'
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+    -   id: check-yaml


### PR DESCRIPTION
To use this, install [pre-commit](https://pre-commit.com/) and then run the following command within the working directory:
```
pre-commit install
```
`clang-format` will then automatically be run before any commit, aboring commit and changing files if necessary.