### PR TITLE
Load monitorrc from /ROMPath/ROMBaseFilename.monitorrc

### DIFF
--- a/Monitor/TMonitor.cpp
+++ b/Monitor/TMonitor.cpp
@@ -105,7 +105,7 @@ TMonitor::TMonitor(
 	TBufferLog* inLog,
 	TEmulator* inEmulator,
 	TSymbolList* inSymbolList,
-	const char* inROMPath) :
+	const char* inMonitorStartupScriptPath) :
 		TMonitorCore(inSymbolList),
 		mEmulator(inEmulator),
 		mProcessor(inEmulator->GetProcessor()),
@@ -115,7 +115,7 @@ TMonitor::TMonitor(
 		mCommand(kNop),
 		mFilename(nullptr),
 		mLastScreenHalted(true),
-		mROMPath(strdup(inROMPath))
+		mMonitorStartupScriptPath(strdup(inMonitorStartupScriptPath))
 {
 	mMemory = inEmulator->GetMemory();
 
@@ -169,7 +169,7 @@ TMonitor::Run()
 	// At first, we're halted.
 	mHalted = true;
 
-	// If the user put a script at /ROMPath/monitorrc, run it.
+	// If the user put a script at /ROMPath/ROMBaseName.monitorrc, run it.
 	// This is used to set the default path, breakpoints, etc.
 	ExecuteStartupScript();
 
@@ -539,11 +539,9 @@ Boolean
 TMonitor::ExecuteStartupScript()
 {
 	bool theResult = true;
-	char buf[2048];
-	snprintf(buf, 2048, "%s/monitorrc", mROMPath);
-	if (::access(buf, 4 /*R_OK*/) == 0)
+	if (::access(mMonitorStartupScriptPath, 4 /*R_OK*/) == 0)
 	{
-		theResult = ExecuteScript(buf);
+		theResult = ExecuteScript(mMonitorStartupScriptPath);
 	}
 	return theResult;
 }
@@ -1335,7 +1333,7 @@ TMonitor::ExecuteCommand(const char* inCommand)
 		PrintNSRef(theArgInt);
 	} else if (::strcmp(inCommand, "cdr") == 0)
 	{
-		::chdir(mROMPath);
+		::chdir(mMonitorStartupScriptPath);
 	} else if (inCommand[0] == '!')
 	{
 		theResult = ExecuteScript(inCommand + 1);
@@ -1432,7 +1430,7 @@ void
 TMonitor::PrintScriptingHelp()
 {
 	PrintLine("Scripting can run many Monitor commands in a text file.", MONITOR_LOG_INFO);
-	PrintLine("When Einstein starts, the script /ROMpath/monitorrc is", MONITOR_LOG_INFO);
+	PrintLine("When Einstein starts, the script /ROMpath/ROMBaseName.monitorrc is", MONITOR_LOG_INFO);
 	PrintLine("executed first.", MONITOR_LOG_INFO);
 	PrintLine("", MONITOR_LOG_INFO);
 	PrintLine(" !filename          run a script file", MONITOR_LOG_INFO);

--- a/Monitor/TMonitor.h
+++ b/Monitor/TMonitor.h
@@ -57,7 +57,7 @@ public:
 		TBufferLog* inLog,
 		TEmulator* inEmulator,
 		TSymbolList* inSymbolList,
-		const char* inROMPath);
+		const char* inMonitorStartupScriptPath);
 
 	///
 	/// Destructor.
@@ -408,7 +408,7 @@ private:
 	int mSocketPair[2]; ///< Socket pair for monitor state changes.
 #endif
 	Boolean mLastScreenHalted; ///< If last screen was halted.
-	char* mROMPath; ///< path to the ROM fle directory
+	char* mMonitorStartupScriptPath; ///< path to the ROM fle directory
 
 	Boolean mRunOnStartup = false; ///< Run the emulation as soon as the monitor starts
 };

--- a/app/FLTK/TFLApp.cpp
+++ b/app/FLTK/TFLApp.cpp
@@ -1304,11 +1304,14 @@ TFLApp::InitMonitor(const char* theROMImagePath)
 #endif
 #endif
 
-	char theSymbolListPath[FL_PATH_MAX];
-	strncpy(theSymbolListPath, theROMImagePath, FL_PATH_MAX);
-	fl_filename_setext(theSymbolListPath, FL_PATH_MAX, ".symbols");
-	mSymbolList = new TSymbolList(theSymbolListPath);
-	mMonitor = new TFLMonitor(mMonitorLog, mEmulator, mSymbolList, theROMImagePath);
+	char theSymbolListOrMonitorRcPath[FL_PATH_MAX];
+	strncpy(theSymbolListOrMonitorRcPath, theROMImagePath, FL_PATH_MAX);
+	fl_filename_setext(theSymbolListOrMonitorRcPath, FL_PATH_MAX, ".symbols");
+	mSymbolList = new TSymbolList(theSymbolListOrMonitorRcPath);
+
+	fl_filename_setext(theSymbolListOrMonitorRcPath, FL_PATH_MAX, ".monitorrc");
+	mMonitor = new TFLMonitor(mMonitorLog, mEmulator, mSymbolList, theSymbolListOrMonitorRcPath);
+
 	KPrintf("Booting... (Monitor enabled)\n");
 }
 


### PR DESCRIPTION
Previous code didn't work because it was trying to load `/ROMPath/ROMFileName/monitorrc` but claimed it would load `/ROMPath/monitorrc`.

Now it will attempt to load `/ROMPath/ROMBaseName.monitorrc` 
So if your ROM file is `/einstein-data/737041.rom` the monitor will look for `/einstein-data/737041.monitorrc` which makes more sense to me...

OTOH, this breaks the `cdr` monitor command though.