### PR TITLE
Support for building under OpenBSD

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,6 +6,7 @@
 * Building Einstein with Cocoa on macOS in 64 bit Universal
 * Building Einstein with FLTK on macOS in 64 bit with Xcode
 * Building Einstein on Linux in 64 bit
+* Building Einstein on OpenBSD in 64 bit
 * Building Einstein on Windows 10/11
 * Buidling Einstein for Android
 * Building Einstein for iOS
@@ -195,6 +196,63 @@ cd macemu/BasiliskII/src/Unix
     --with-sdl-audio --with-sdl-framework
 make
 ```
+
+## Building Einstein on OpenBSD 64 bit
+
+Tested on OpenBSD 7.1/amd64-stable on June 30th 2022
+
+These instructions will create an Intel executable when run on an Intel system, and an ARM executable on ARM systems.
+
+### Using the command line
+
+Install various packages that are needed to compile FLTK, newt64, and Einstein. This worked for me:
+
+```bash
+doas pkg_add git \
+  cmake \
+  autoconf \
+  bison \
+  ffi \
+  pulseaudio
+```
+
+Now download and build all components:
+
+```bash
+# -- Get the Einstein source code from GitHub
+git clone https://github.com/pguyot/Einstein.git Einstein
+cd Einstein/
+# -- Get the FLTK source code from GitHub
+git clone https://github.com/fltk/fltk.git fltk
+# -- Get the newt64 source code from GitHub
+git clone https://github.com/MatthiasWM/NEWT64.git newt64
+# -- Compile FLTK
+cmake -S fltk -B fltk/build \
+    -D OPTION_USE_SYSTEM_LIBJPEG=Off \
+    -D OPTION_USE_SYSTEM_ZLIB=Off \
+    -D OPTION_USE_SYSTEM_LIBPNG=Off \
+    -D FLTK_BUILD_TEST=Off \
+    -D OPTION_USE_GL=Off \
+    -D CMAKE_BUILD_TYPE=Release
+cmake --build fltk/build
+# -- Compile newt64
+cmake -S newt64 -B newt64/build \
+    -D CMAKE_BUILD_TYPE=Release
+cmake --build newt64/build
+# -- Compile Einstein
+LOCALBASE=/usr/local cmake -S . -B build \
+    -D CMAKE_BUILD_TYPE=Release
+cmake --build build --target Einstein
+```
+
+Your Einstein app will be in build/Einstein, but you can move it to your /usr/local/bin folder for easy access:
+
+```bash
+# -- Optional: Copy Einstein to the binaries folder
+doas cp build/Einstein /usr/local/bin
+```
+
+Continue with setting up the ROM as described in the manual. Enjoy.
 
 ## Building Einstein on Windows 10/11 with VisualStudi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
 
 	# Linux: nothing to do here
 
+elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" )
+
+	set_property ( GLOBAL PROPERTY FIND_LIBRARY_USE_OPENBSD_VERSIONING 1 )
+
 elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Windows" )
 
 	# allow to build with multithreading libraries with VisualC
@@ -265,7 +269,7 @@ if ( ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" )
 		add_dependencies( Einstein EinsteinTests )
 	endif ()
 
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
+elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" )
 
 	# create the application
 	add_executable ( Einstein
@@ -308,6 +312,27 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
 		fltk
 		pthread
 	)
+
+	if ( ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" )
+		# Under OpenBSD, libffi is in ports (i.e. /usr/local) not base (i.e. /usr)
+		find_library ( ffi_lib NAMES ffi )
+		find_file ( ffi_incl NAMES ffi.h )
+		if ( ffi_lib MATCHES ".*NOTFOUND" OR ffi_incl MATCHES ".*NOTFOUND" )
+			message ( FATAL_ERROR "libffi not found!" )
+		else ()
+			get_filename_component ( ffi_lib_path ${ffi_lib} DIRECTORY )
+			get_filename_component ( ffi_incl_path ${ffi_incl} DIRECTORY )
+			message ( STATUS "libffi found in " ${ffi_lib_path} ) target_include_directories ( Einstein SYSTEM PUBLIC ${ffi_incl_path} )
+			target_link_libraries ( Einstein ${ffi_lib} )
+		endif ()
+
+		# Under OpenBSD, X11 is in /usr/X11R6
+		include ( FindX11 )
+		if ( X11_FOUND )
+			target_include_directories ( Einstein SYSTEM PUBLIC ${X11_INCLUDE_DIR} )
+			target_link_libraries ( Einstein ${X11_LIBRARIES} )
+		endif ()
+	endif ()
 
 elseif ( WIN32 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,8 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL 
 		else ()
 			get_filename_component ( ffi_lib_path ${ffi_lib} DIRECTORY )
 			get_filename_component ( ffi_incl_path ${ffi_incl} DIRECTORY )
-			message ( STATUS "libffi found in " ${ffi_lib_path} ) target_include_directories ( Einstein SYSTEM PUBLIC ${ffi_incl_path} )
+			message ( STATUS "libffi found in " ${ffi_lib_path} )
+			target_include_directories ( Einstein SYSTEM PUBLIC ${ffi_incl_path} )
 			target_link_libraries ( Einstein ${ffi_lib} )
 		endif ()
 

--- a/Emulator/NativeCalls/CMakeLists.txt
+++ b/Emulator/NativeCalls/CMakeLists.txt
@@ -18,7 +18,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 		Emulator/NativeCalls/TObjCBridgeCalls.mm
 		Emulator/NativeCalls/TObjCBridgeCalls.h
 	)
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
 	list (APPEND common_sources
 			Emulator/NativeCalls/NativeCallsDefines.h
 			Emulator/NativeCalls/TNativeCalls.cpp

--- a/Emulator/Serial/CMakeLists.txt
+++ b/Emulator/Serial/CMakeLists.txt
@@ -31,7 +31,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 		Emulator/Serial/TPtySerialPortManager.cpp
 		Emulator/Serial/TPtySerialPortManager.h
 	)
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
 	list (APPEND common_sources
 		Emulator/Serial/TSerialHostPort.h
 		Emulator/Serial/TSerialHostPortDirect.h

--- a/Emulator/Sound/CMakeLists.txt
+++ b/Emulator/Sound/CMakeLists.txt
@@ -20,7 +20,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 		Emulator/Sound/TCoreAudioSoundManager.cpp
 		Emulator/Sound/TCoreAudioSoundManager.h
 	)
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
 	list (APPEND app_sources
 		Emulator/Sound/TPulseAudioSoundManager.cpp
 		Emulator/Sound/TPulseAudioSoundManager.h


### PR DESCRIPTION
This extends the existing `cmake` Linux build support to include OpenBSD (tested under OpenBSD 7.1/amd64-stable), with a couple additions for find FFI & X11 libs & includes as they they're found in `/usr/local` & `/usr/X11R6`, respectively. I have included documentation in `BUILDING.md`, as well.

This should be a good basis for building under other BSDs too.

Note: Attached is a required patch for [MatthiasWM/NEWT64](https://github.com/MatthiasWM/NEWT64). I have my own fork of the original [gnue/NEWT0](https://github.com/gnue/NEWT0) repo, which NEWT64 was forked from, and they've diverged, so I can't create a new PR directly:

[newt64_openbsd_support.patch.txt](https://github.com/pguyot/Einstein/files/9030986/newt64_openbsd_support.patch.txt)
