### PR TITLE
iOS printing support

### DIFF
--- a/Emulator/Printer/TIOSPrinterManager.h
+++ b/Emulator/Printer/TIOSPrinterManager.h
@@ -1,0 +1,133 @@
+// ==============================
+// File:			TIOSPrinterManager.h
+// Project:			Einstein
+//
+// Copyright 2022 by Jesús A. Álvarez (zydeco@namedfork.net).
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+// ==============================
+// $Id$
+// ==============================
+
+#ifndef _TIOSPRINTERMANAGER_H
+#define _TIOSPRINTERMANAGER_H
+
+#include "Emulator/Printer/TPrinterManager.h"
+
+class TLog;
+class TMemory;
+@class TIOSPrintPageRenderer;
+
+///
+/// Class to handle a single printer.
+/// This class is subclassed by host implementations.
+///
+class TIOSPrinterManager : public TPrinterManager
+{
+public:
+	///
+	/// Constructor from a log.
+	///
+	/// \param inLog        log interface (can be null)
+	///
+	TIOSPrinterManager(TLog* inLog = nil);
+
+	///
+	/// Destructor.
+	///
+	~TIOSPrinterManager() override;
+
+	///
+	/// Printer is no longer used
+	///
+	void Delete(KUInt32 inDrvr) override;
+
+	///
+	/// Open a connection to the host printer
+	///
+	KUInt32 Open(KUInt32 inDrvr) override;
+
+	///
+	/// Close the connection to the printer
+	///
+	KUInt32 Close(KUInt32 inDrvr) override;
+
+	///
+	/// Start to print a page
+	///
+	KUInt32 OpenPage(KUInt32 inDrvr) override;
+
+	///
+	/// Finish printing a page
+	///
+	KUInt32 ClosePage(KUInt32 inDrvr) override;
+
+	///
+	/// NewtonOS sends a band of pixel data to be printed
+	///
+	KUInt32 ImageBand(KUInt32 inDrvr, KUInt32 inBand, KUInt32 inRect) override;
+
+	///
+	/// User or Newton wants to cancel the current print job.
+	///
+	void CancelJob(KUInt32 inDrvr, KUInt32 inAsyncCancel) override;
+
+	///
+	/// Fill in the Info structure about our paper size and print resolution
+	///
+	void GetPageInfo(KUInt32 inDrvr, KUInt32 inInfo) override;
+
+	///
+	/// Fill in the structure to have bands delivered a certain way
+	///
+	void GetBandPrefs(KUInt32 inDrvr, KUInt32 inPrefs) override;
+
+protected:
+	static constexpr KUInt8 kSubtype72dpi = 0;
+	static constexpr KUInt8 kSubtype150dpi = 1;
+	static constexpr KUInt8 kSubtype300dpi = 2;
+
+	KUInt8 GetSubType(KUInt32 inDrvr);
+
+	enum class State {
+		Uninitialized,
+		Allocated,
+		Open,
+		PageOpen
+	};
+	State mState = State::Uninitialized;
+
+	TIOSPrintPageRenderer* mRenderer = nil;
+
+	KUInt32 mDrvr = 0;
+
+	struct PrPageInfo {
+		KUInt32 horizontalDPI; // DPI as a fixed point value
+		KUInt32 verticalDPI;
+		KUInt16 width; // page width in pixels
+		KUInt16 height;
+	} mPageInfo;
+
+	struct PixelMap {
+		KUInt32 baseAddr;
+		KUInt16 rowBytes, pad; // 300, pads to long
+		KUInt16 top, left, bottom, right;
+		KUInt32 pixMapFlags; // 0x40000101, ptr, dot printer, 1 bit
+							 // Point      deviceRes;    // resolution of input device (0 indicates kDefaultDPI
+							 // UChar*      grayTable;    // gray tone table
+	} mBand;
+};
+
+#endif

--- a/Emulator/Printer/TIOSPrinterManager.mm
+++ b/Emulator/Printer/TIOSPrinterManager.mm
@@ -1,0 +1,352 @@
+// ==============================
+// File:			TIOSPrinterManager.mm
+// Project:			Einstein
+//
+// Copyright 2022 by Jesús A. Álvarez (zydeco@namedfork.net).
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+// ==============================
+// $Id$
+// ==============================
+
+#include "TIOSPrinterManager.h"
+
+#include "Emulator/TMemory.h"
+
+@interface TIOSPrintPageRenderer : UIPrintPageRenderer
+@property CGSize pageSize;
+@property CGFloat printerDpi;
+- (KUInt32)openPage;
+- (KUInt32)closePage;
+- (KUInt32)renderImageBand:(const KUInt8*)imageBits bytesPerRow:(KUInt16)rowBytes inRect:(CGRect)rect;
+@end
+
+TIOSPrinterManager::TIOSPrinterManager(TLog* inLog) :
+		TPrinterManager(inLog)
+{
+	(void) mLog;
+}
+
+/**
+ Delete the printer manager and all allocated resources.
+ */
+TIOSPrinterManager::~TIOSPrinterManager()
+{
+	mRenderer = nil;
+}
+
+/**
+ Close any active printer connection.
+
+ Roll back the state of the connection to Allocated.
+ */
+void
+TIOSPrinterManager::Delete(KUInt32 inDrvr)
+{
+	mDrvr = inDrvr;
+
+	// nothing to do
+	if (mState == State::Uninitialized)
+		return;
+
+	// we are already at the requested state
+	if (mState == State::Allocated)
+		return;
+
+	if (mState == State::Open)
+		mState = State::Allocated;
+}
+
+/**
+ iOS needs to know the number of pages before the printing UI is shown: everything must be printed
+ */
+KUInt32
+TIOSPrinterManager::Open(KUInt32 inDrvr)
+{
+	mDrvr = inDrvr;
+
+	// Fail if printing is not supported
+	if (![UIPrintInteractionController isPrintingAvailable])
+	{
+		return kPR_ERR_NotFound;
+	}
+
+	// Is the connection to the printer still open? Then we are done.
+	if (mState == State::Open)
+		return 0;
+
+	// Create page renderer
+	mRenderer = [TIOSPrintPageRenderer new];
+
+	mState = State::Open;
+
+	return 0;
+}
+
+/**
+ Close the connection to the printer and flush all pages.
+ */
+KUInt32
+TIOSPrinterManager::Close(KUInt32 inDrvr)
+{
+	mDrvr = inDrvr;
+
+	if (mRenderer == nil || mState != State::Open)
+		return kPR_ERR_NewtonError;
+
+	dispatch_sync(dispatch_get_main_queue(), ^{
+		UIPrintInteractionController* printInteractionController = UIPrintInteractionController.sharedPrintController;
+		printInteractionController.printPageRenderer = mRenderer;
+		[printInteractionController presentAnimated:YES
+								  completionHandler:^(UIPrintInteractionController* _Nonnull printInteractionController, BOOL completed, NSError* _Nullable error) {
+									  // TODO: handle errors?
+									  this->mRenderer = nil;
+								  }];
+	});
+
+	return 0;
+}
+
+/**
+ Start a new page in our printing process.
+ This call may pop up dialogs (progress, error, etc.), so it must be called
+ from the UI thread.
+ */
+KUInt32
+TIOSPrinterManager::OpenPage(KUInt32 inDrvr)
+{
+	mDrvr = inDrvr;
+	return [mRenderer openPage];
+}
+
+/**
+ Finsh the current page.
+ */
+KUInt32
+TIOSPrinterManager::ClosePage(KUInt32 inDrvr)
+{
+	mDrvr = inDrvr;
+	return [mRenderer closePage];
+}
+
+KUInt32
+TIOSPrinterManager::ImageBand(KUInt32 inDrvr, KUInt32 inBand, KUInt32 inRect)
+{
+	mDrvr = inDrvr;
+	(void) inRect;
+
+	KUInt32 ret = 0;
+
+	// TODO: we currently only support 1 bit bitmaps
+	// TODO: we should give an error message for unsupported bitmap formats
+	// #define    kPixMapStorage    0xC0000000  // to mask off the appropriate bits
+	// #define    kPixMapHandle    0x00000000  // baseAddr is a handle
+	// #define    kPixMapPtr      0x40000000  // baseAddr is a pointer
+	// #define    kPixMapOffset    0x80000000  // baseAddr is an offset from the PixelMap
+	// #define    kPixMapLittleEndian  0x20000000  // pixMap is little endian
+	// #define    kPixMapAllocated  0x10000000  // pixMap "owns" the bits memory
+	// #ifdef QD_Gray
+	// #define    kPixMapGrayTable  0x08000000  // grayTable field exists
+	// #define    kPixMapNoPad    0x04000000  // direct pixel format, no pad byte
+	// #define    kPixMapByComponent  0x02000000  // direct pixel format, stored by component
+	// #define    kPixMapAntiAlias  0x01000000  // antialiasing ink text
+	// #endif
+	// #define    kPixMapVersionMask  0x0000F000  // version of this struct
+	// #define    kPixMapDeviceType  0x00000F00  // bits 8..11 are device type code
+	// #define    kPixMapDevScreen  0x00000000  //   screen or offscreen bitmap
+	// #define    kPixMapDevDotPrint  0x00000100  //   dot matrix printer
+	// #define    kPixMapDevPSPrint  0x00000200  //   postscript printer
+	// #define    kPixMapDepth    0x000000FF  // bits 0..7 are chunky pixel depth
+
+	mMemory->FastReadBuffer(inBand, sizeof(mBand), (KUInt8*) &mBand);
+	mBand.baseAddr = htonl(mBand.baseAddr);
+	mBand.rowBytes = htons(mBand.rowBytes);
+	mBand.top = htons(mBand.top);
+	mBand.left = htons(mBand.left);
+	mBand.bottom = htons(mBand.bottom);
+	mBand.right = htons(mBand.right);
+	mBand.pixMapFlags = htonl(mBand.pixMapFlags);
+
+	int w = mBand.right - mBand.left;
+	int h = mBand.bottom - mBand.top;
+	int rowWords = (mBand.rowBytes + 3) / 4; // row bytes must be 32bit aligned
+	int bytes = rowWords * 4 * h;
+	KUInt8* bits = (KUInt8*) malloc(bytes);
+	mMemory->FastReadBuffer(mBand.baseAddr, bytes, bits);
+	ret = [mRenderer renderImageBand:bits bytesPerRow:mBand.rowBytes inRect:CGRectMake(mBand.left, mBand.top, w, h)];
+	free(bits);
+
+	return ret;
+}
+
+void
+TIOSPrinterManager::CancelJob(KUInt32 inDrvr, KUInt32 inAsyncCancel)
+{
+	(void) inDrvr;
+	(void) inAsyncCancel;
+}
+
+void
+TIOSPrinterManager::GetPageInfo(KUInt32 inDrvr, KUInt32 inInfo)
+{
+	mDrvr = inDrvr;
+
+	mMemory->FastReadBuffer(inInfo, sizeof(mPageInfo), (KUInt8*) &mPageInfo);
+	mPageInfo.horizontalDPI = ntohl(mPageInfo.horizontalDPI);
+	mPageInfo.verticalDPI = ntohl(mPageInfo.verticalDPI);
+	mPageInfo.width = ntohs(mPageInfo.width);
+	mPageInfo.height = ntohs(mPageInfo.height);
+
+	int dpi = 300;
+	switch (GetSubType(mDrvr))
+	{
+		case kSubtype72dpi:
+			dpi = 72;
+			break;
+		case kSubtype150dpi:
+			dpi = 150;
+			break;
+		case kSubtype300dpi:
+			dpi = 300;
+			break;
+	}
+
+	mPageInfo.horizontalDPI = (dpi << 16);
+	mPageInfo.verticalDPI = (dpi << 16);
+	mRenderer.printerDpi = dpi;
+
+	// Read paper size from user defaults
+	// It's too soon to read from UIKit, and impossible to read from NewtonOS
+	NSUserDefaults* prefs = [NSUserDefaults standardUserDefaults];
+	CGSize printableSize = CGSizeFromString([prefs stringForKey:@"printable_size"]);
+	if (printableSize.width <= 0 || printableSize.height <= 0)
+	{
+		// Default iOS reported size for US Letter
+		printableSize = { .width = 8.0, .height = 9.88897 };
+	}
+
+	mPageInfo.width = floor(dpi * printableSize.width);
+	mPageInfo.height = floor(dpi * printableSize.height);
+	mRenderer.pageSize = CGSizeMake(mPageInfo.width, mPageInfo.height);
+
+	// convert to guest endianness
+	mPageInfo.horizontalDPI = htonl(mPageInfo.horizontalDPI);
+	mPageInfo.verticalDPI = htonl(mPageInfo.verticalDPI);
+	mPageInfo.width = htons(mPageInfo.width);
+	mPageInfo.height = htons(mPageInfo.height);
+	mMemory->FastWriteBuffer(inInfo, sizeof(mPageInfo), (KUInt8*) &mPageInfo);
+}
+
+void
+TIOSPrinterManager::GetBandPrefs(KUInt32 inDrvr, KUInt32 inPrefs)
+{
+	// The driver sets the default to a 50 pixel band
+	//	typedef struct DotPrinterPrefs {
+	//		long		minBand;				/* smallest useable band			*/
+	//		long		optimumBand;			/* a good size to try to default	*/
+	//		Boolean		asyncBanding;			/* true if band data sent async		*/
+	//		Boolean		wantMinBounds;			/* true if minrect is useful		*/
+	//	} DotPrinterPrefs;
+	(void) inDrvr;
+	(void) inPrefs;
+}
+
+KUInt8
+TIOSPrinterManager::GetSubType(KUInt32 inDrvr)
+{
+	KUInt8 subtype = 255;
+	mMemory->ReadB(inDrvr + 31, subtype);
+	return subtype;
+}
+
+@implementation TIOSPrintPageRenderer {
+	NSMutableArray<UIImage*>* pages;
+	CGContextRef currentCtx;
+	CGColorSpaceRef gColorSpace, bwColorSpace;
+}
+
+- (instancetype)init
+{
+	if ((self = [super init]))
+	{
+		pages = [NSMutableArray new];
+		currentCtx = NULL;
+		_pageSize = CGSizeZero;
+		gColorSpace = CGColorSpaceCreateDeviceGray();
+		uint8_t colors[] = { 255, 0 };
+		bwColorSpace = CGColorSpaceCreateIndexed(gColorSpace, 1, colors);
+	}
+	return self;
+}
+
+- (void)dealloc
+{
+	if (currentCtx)
+	{
+		CGContextRelease(currentCtx);
+	}
+	CGColorSpaceRelease(bwColorSpace);
+	CGColorSpaceRelease(gColorSpace);
+}
+
+- (void)drawPageAtIndex:(NSInteger)pageIndex inRect:(CGRect)printableRect
+{
+	[pages[pageIndex] drawAtPoint:printableRect.origin];
+}
+
+- (NSInteger)numberOfPages
+{
+	return pages.count;
+}
+
+- (KUInt32)openPage
+{
+	NSAssert(currentCtx == NULL, @"openPage without closing previous page!");
+
+	// create context for new page
+	size_t width = floor(_pageSize.width);
+	size_t height = floor(_pageSize.height);
+	currentCtx = CGBitmapContextCreate(NULL, width, height, 8, width, gColorSpace, kCGImageAlphaNone);
+	CGContextSetGrayFillColor(currentCtx, 1.0, 1.0);
+	CGContextFillRect(currentCtx, CGRectMake(0, 0, width, height));
+	return 0;
+}
+
+- (KUInt32)closePage
+{
+	CGImageRef imageRef = CGBitmapContextCreateImage(currentCtx);
+	[pages addObject:[UIImage imageWithCGImage:imageRef scale:_printerDpi / 72.0 orientation:UIImageOrientationUp]];
+	CGImageRelease(imageRef);
+	CGContextRelease(currentCtx);
+	currentCtx = NULL;
+
+	return 0;
+}
+
+- (KUInt32)renderImageBand:(const KUInt8*)imageBits bytesPerRow:(KUInt16)rowBytes inRect:(CGRect)rect
+{
+	// create image from current band
+	CGDataProviderRef dataProvider = CGDataProviderCreateWithData(NULL, imageBits, rect.size.height * rowBytes, NULL);
+	CGImageRef image = CGImageCreate(rect.size.width, rect.size.height, 1, 1, rowBytes, bwColorSpace, kCGImageAlphaNone, dataProvider, NULL, false, kCGRenderingIntentDefault);
+	CGDataProviderRelease(dataProvider);
+
+	// draw in current page context
+	rect.origin.y = _pageSize.height - rect.origin.y;
+	CGContextDrawImage(currentCtx, rect, image);
+	CGImageRelease(image);
+	return 0;
+}
+
+@end

--- a/Emulator/TNativePrimitives.cpp
+++ b/Emulator/TNativePrimitives.cpp
@@ -3235,8 +3235,7 @@ TNativePrimitives::ExecuteHostiOSNativeiOS(KUInt32 inInstruction)
 }
 #endif
 
-#ifdef TARGET_UI_FLTK
-#include <FL/Fl_Printer.H>
+#if defined(TARGET_UI_FLTK) || TARGET_IOS
 // -------------------------------------------------------------------------- //
 //  * ExecutePrinterDriverNative( KUInt32 )
 // -------------------------------------------------------------------------- //

--- a/_Build_/Xcode/Einstein.xcodeproj/project.pbxproj
+++ b/_Build_/Xcode/Einstein.xcodeproj/project.pbxproj
@@ -92,6 +92,9 @@
 		2389E98E1A1E4D4A0001A8C5 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CAFBF41241F7E600A0382E /* AudioToolbox.framework */; };
 		2389E98F1A1E4D4A0001A8C5 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CAFCF8124200C100A0382E /* CoreGraphics.framework */; };
 		2389E9911A1E4D4A0001A8C5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C97C7E1B124282A600CDCD05 /* Foundation.framework */; };
+		288F814A288C140D007CC87B /* TPrinterManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 288F8145288C140D007CC87B /* TPrinterManager.cpp */; };
+		288F814B288C140D007CC87B /* TPrinterManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 288F8145288C140D007CC87B /* TPrinterManager.cpp */; };
+		288F8153288C1984007CC87B /* TIOSPrinterManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 288F8150288C1983007CC87B /* TIOSPrinterManager.mm */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		A78AB268278074400047B122 /* TSerialHostPortDirect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78AB265278074400047B122 /* TSerialHostPortDirect.cpp */; };
 		A78AB269278074400047B122 /* TSerialHostPortDirect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78AB265278074400047B122 /* TSerialHostPortDirect.cpp */; };
@@ -453,6 +456,10 @@
 		2360EB291A1E85EB00893927 /* Launch Screen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = "Launch Screen.xib"; sourceTree = "<group>"; };
 		2389E9331A1E3A5C0001A8C5 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		2389E9961A1E4D4A0001A8C5 /* iOSEinstein.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEinstein.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		288F8145288C140D007CC87B /* TPrinterManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TPrinterManager.cpp; sourceTree = "<group>"; };
+		288F8148288C140D007CC87B /* TPrinterManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPrinterManager.h; sourceTree = "<group>"; };
+		288F8150288C1983007CC87B /* TIOSPrinterManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TIOSPrinterManager.mm; sourceTree = "<group>"; };
+		288F8151288C1983007CC87B /* TIOSPrinterManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TIOSPrinterManager.h; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		8D1107320486CEB800E47090 /* Einstein.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Einstein.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -901,6 +908,17 @@
 			name = Storyboards;
 			sourceTree = "<group>";
 		};
+		288F8144288C140D007CC87B /* Printer */ = {
+			isa = PBXGroup;
+			children = (
+				288F8145288C140D007CC87B /* TPrinterManager.cpp */,
+				288F8148288C140D007CC87B /* TPrinterManager.h */,
+				288F8150288C1983007CC87B /* TIOSPrinterManager.mm */,
+				288F8151288C1983007CC87B /* TIOSPrinterManager.h */,
+			);
+			path = Printer;
+			sourceTree = "<group>";
+		};
 		29B97314FDCFA39411CA2CEA /* Einstein */ = {
 			isa = PBXGroup;
 			children = (
@@ -1221,6 +1239,7 @@
 				C99E33F3111B7C07002165EC /* JIT */,
 				C962429411B69A6E00EE66F3 /* Network */,
 				C99E346F111B7C07002165EC /* PCMCIA */,
+				288F8144288C140D007CC87B /* Printer */,
 				C99E34A3111B7C08002165EC /* Serial */,
 				C99E34A9111B7C08002165EC /* Sound */,
 				C99E348D111B7C08002165EC /* Screen */,
@@ -1784,6 +1803,7 @@
 				2389E94F1A1E4D4A0001A8C5 /* TJITGeneric.cpp in Sources */,
 				2389E9501A1E4D4A0001A8C5 /* TJITGeneric_BlockDataTransfer.cpp in Sources */,
 				2389E9511A1E4D4A0001A8C5 /* TJITGeneric_DataProcessingPSRTransfer.cpp in Sources */,
+				288F814B288C140D007CC87B /* TPrinterManager.cpp in Sources */,
 				2389E9521A1E4D4A0001A8C5 /* TJITGeneric_DataProcessingPSRTransfer_ArithmeticOp.cpp in Sources */,
 				2389E9531A1E4D4A0001A8C5 /* TJITGeneric_DataProcessingPSRTransfer_LogicalOp.cpp in Sources */,
 				C97F21BB2779F66600539FAB /* TTcpClientSerialPortManager.cpp in Sources */,
@@ -1791,6 +1811,7 @@
 				DA52C8931A409164008A17D0 /* TJITGenericROMPatch.cpp in Sources */,
 				2389E9551A1E4D4A0001A8C5 /* TJITGeneric_DataProcessingPSRTransfer_MRS.cpp in Sources */,
 				2389E9561A1E4D4A0001A8C5 /* TJITGeneric_DataProcessingPSRTransfer_MSR.cpp in Sources */,
+				288F8153288C1984007CC87B /* TIOSPrinterManager.mm in Sources */,
 				2389E9571A1E4D4A0001A8C5 /* TJITGeneric_DataProcessingPSRTransfer_TestOp.cpp in Sources */,
 				2389E9581A1E4D4A0001A8C5 /* TJITGenericPage.cpp in Sources */,
 				2389E9591A1E4D4A0001A8C5 /* TJITGeneric_Test.cpp in Sources */,
@@ -1947,6 +1968,7 @@
 				F1647FC513198E6A001603BE /* TCocoaMonitorController.mm in Sources */,
 				F164801A13199758001603BE /* TMacMonitor.mm in Sources */,
 				C901E51A132655D50074513E /* UUTF16CStr.cpp in Sources */,
+				288F814A288C140D007CC87B /* TPrinterManager.cpp in Sources */,
 				C901E51D132655E00074513E /* UUTF16Conv.cpp in Sources */,
 				C901E5221326560B0074513E /* TStream.cpp in Sources */,
 				C901E5231326560C0074513E /* TFileStream.cpp in Sources */,

--- a/app/iEinstein/Classes/iEinsteinAppDelegate.mm
+++ b/app/iEinstein/Classes/iEinsteinAppDelegate.mm
@@ -39,6 +39,7 @@
 	NSDictionary* defaults = [NSDictionary dictionaryWithObjectsAndKeys:
 											   [NSNumber numberWithInt:0], @"screen_resolution",
 										   [NSNumber numberWithBool:NO], @"clear_flash_ram",
+										   @"{8,9.88897}", @"printable_size",
 										   nil];
 
 	[[NSUserDefaults standardUserDefaults] registerDefaults:defaults];

--- a/app/iEinstein/Classes/iEinsteinViewController.h
+++ b/app/iEinstein/Classes/iEinsteinViewController.h
@@ -30,6 +30,7 @@
 class TNetworkManager;
 class TSoundManager;
 class TScreenManager;
+class TPrinterManager;
 class TROMImage;
 class TEmulator;
 class TPlatformManager;
@@ -40,6 +41,7 @@ class TLog;
 	TNetworkManager* mNetworkManager;
 	TSoundManager* mSoundManager;
 	TScreenManager* mScreenManager;
+	TPrinterManager* mPrinterManager;
 	TROMImage* mROMImage;
 	TEmulator* mEmulator;
 	TPlatformManager* mPlatformManager;

--- a/app/iEinstein/Classes/iEinsteinViewController.mm
+++ b/app/iEinstein/Classes/iEinsteinViewController.mm
@@ -27,6 +27,7 @@
 #include "Emulator/Log/TStdOutLog.h"
 #include "Emulator/Network/TNetworkManager.h"
 #include "Emulator/Platform/TPlatformManager.h"
+#include "Emulator/Printer/TIOSPrinterManager.h"
 #include "Emulator/ROM/TAIFROMImageWithREXes.h"
 #include "Emulator/ROM/TFlatROMImageWithREX.h"
 #include "Emulator/ROM/TROMImage.h"
@@ -207,6 +208,9 @@ iEinsteinViewController ()
 		mSoundManager = NULL;
 	}
 
+	delete mPrinterManager;
+	mPrinterManager = NULL;
+
 	if (mROMImage)
 	{
 		delete mROMImage;
@@ -237,6 +241,7 @@ iEinsteinViewController ()
 	mNetworkManager = NULL;
 	mSoundManager = NULL;
 	mScreenManager = NULL;
+	mPrinterManager = NULL;
 	mROMImage = NULL;
 	mEmulator = NULL;
 	mPlatformManager = NULL;
@@ -352,6 +357,9 @@ iEinsteinViewController ()
 
 	[einsteinView setScreenManager:mScreenManager];
 
+	// Create the printer manager.
+	mPrinterManager = new TIOSPrinterManager(mLog);
+
 	// Create the emulator.
 
 	NSString* theFlashPath = [docdir stringByAppendingPathComponent:@"flash"];
@@ -359,7 +367,7 @@ iEinsteinViewController ()
 
 	mEmulator = new TEmulator(
 		mLog, mROMImage, [theFlashPath fileSystemRepresentation],
-		mSoundManager, mScreenManager, mNetworkManager, 0x40 << 16);
+		mSoundManager, mScreenManager, mNetworkManager, 0x40 << 16, mPrinterManager);
 
 	mEmulator->SerialPorts.Initialize(TSerialPorts::kTcpClientDriver,
 		TSerialPorts::kNullDriver,
@@ -367,6 +375,7 @@ iEinsteinViewController ()
 		TSerialPorts::kNullDriver);
 	mPlatformManager = mEmulator->GetPlatformManager();
 	mPlatformManager->SetDocDir([docdir fileSystemRepresentation]);
+	mPrinterManager->SetMemory(mEmulator->GetMemory());
 
 	[einsteinView setEmulator:mEmulator];
 
@@ -439,6 +448,12 @@ iEinsteinViewController ()
 
 	delete mScreenManager;
 	mScreenManager = NULL;
+
+	if (mPrinterManager != NULL)
+	{
+		delete mPrinterManager;
+		mPrinterManager = NULL;
+	}
 
 	delete mROMImage;
 	mROMImage = NULL;

--- a/app/iEinstein/Settings.bundle/Root.plist
+++ b/app/iEinstein/Settings.bundle/Root.plist
@@ -54,6 +54,42 @@
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>
+			<string>Printing Settings</string>
+			<key>FooterText</key>
+			<string>This should match the paper size selected in NewtonOS&apos;s Locale Prefs.</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>Paper Size</string>
+			<key>Key</key>
+			<string>printable_size</string>
+			<key>DefaultValue</key>
+			<string>{8,9.88897}</string>
+			<key>Titles</key>
+			<array>
+				<string>U.S. Letter</string>
+				<string>A4</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>{8,9.88897}</string>
+				<string>{7.76771,10.58188}</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string></string>
+			<key>Key</key>
+			<string></string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
 			<string>Reset</string>
 		</dict>
 		<dict>


### PR DESCRIPTION
I've added printing support to iOS, based on the FLTK implementation.

Key differences:
* UIKit needs to know the number of pages before showing the printing UI, so the print job must be finished on the Newton side before showing iOS's printing UI.
* I've added a setting for paper size, that should be set to mirror the Newton's paper size setting (otherwise things might get clipped). The reported sizes are what iOS reports as printable
 
I tried to read the paper size settings from NewtonOS, but wasn't able to do it from the driver, my attempts to call `GetUserConfig('paperSize)` with `TNewt::MakeSymbol` and calling `NSCallGlobalFn` only resulted in crashes.

Here's a screenshot showing iOS's print dialog:
![Screen Shot 2022-07-27 at 19 04 43](https://user-images.githubusercontent.com/158216/181309401-0080b38b-064b-42f7-8fa0-d808d12e0d80.png)

