### PR TITLE
Fix build on Fedora

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
 		fltk_images
 		fltk_png
 		fltk_z
+		pthread
 		pulse # sound
 	)
 	target_link_libraries ( EinsteinTests

--- a/Emulator/ROM/TAIFROMImageWithREXes.cpp
+++ b/Emulator/ROM/TAIFROMImageWithREXes.cpp
@@ -24,6 +24,7 @@
 #include "TAIFROMImageWithREXes.h"
 
 // ANSI C & POSIX
+#include <time.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/Emulator/ROM/TAIFROMImageWithREXes.cpp
+++ b/Emulator/ROM/TAIFROMImageWithREXes.cpp
@@ -24,12 +24,12 @@
 #include "TAIFROMImageWithREXes.h"
 
 // ANSI C & POSIX
-#include <time.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
 
 #if TARGET_OS_WIN32
 #include <Windows.h>

--- a/Emulator/ROM/TFlatROMImageWithREX.cpp
+++ b/Emulator/ROM/TFlatROMImageWithREX.cpp
@@ -24,12 +24,12 @@
 #include "TFlatROMImageWithREX.h"
 
 // ANSI C & POSIX
-#include <time.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
 
 #if TARGET_OS_WIN32
 #include <Windows.h>

--- a/Emulator/ROM/TFlatROMImageWithREX.cpp
+++ b/Emulator/ROM/TFlatROMImageWithREX.cpp
@@ -24,6 +24,7 @@
 #include "TFlatROMImageWithREX.h"
 
 // ANSI C & POSIX
+#include <time.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Missing includes for `time.h` here.  Won't build on Fedora 36 without it.
Also add missing `pthread` to `target_link_libraries` in CMakeFiles.txt - fixes Github Ubuntu builds.