### PR TITLE
Fix performance hit, clicking output with Linux PulseAudio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
 		fltk_images
 		fltk_png
 		fltk_z
+		pthread
 		pulse # sound
 	)
 	target_link_libraries ( EinsteinTests

--- a/Emulator/ROM/TAIFROMImageWithREXes.cpp
+++ b/Emulator/ROM/TAIFROMImageWithREXes.cpp
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
 
 #if TARGET_OS_WIN32
 #include <Windows.h>

--- a/Emulator/ROM/TFlatROMImageWithREX.cpp
+++ b/Emulator/ROM/TFlatROMImageWithREX.cpp
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
 
 #if TARGET_OS_WIN32
 #include <Windows.h>

--- a/Emulator/Sound/TPulseAudioSoundManager.cpp
+++ b/Emulator/Sound/TPulseAudioSoundManager.cpp
@@ -40,7 +40,7 @@
 
 // Einstein.
 #include "Emulator/Log/TLog.h"
-
+#define DEBUG_SOUND
 // -------------------------------------------------------------------------- //
 // Constantes
 // -------------------------------------------------------------------------- //
@@ -69,14 +69,7 @@ TPulseAudioSoundManager::TPulseAudioSoundManager(TLog* inLog /* = nil */) :
 		goto error;
 	}
 
-	mPAMainLoopAPI = pa_threaded_mainloop_get_api(mPAMainLoop);
-	if (!mPAMainLoopAPI)
-	{
-		errorText = "Can't allocate PulseAudio loop API";
-		goto error;
-	}
-
-	mPAContext = pa_context_new(mPAMainLoopAPI, "Einstein");
+	mPAContext = pa_context_new(pa_threaded_mainloop_get_api(mPAMainLoop), "Einstein");
 	if (!mPAContext)
 	{
 		errorText = "Can't allocate PulseAudio context";
@@ -277,8 +270,8 @@ TPulseAudioSoundManager::ScheduleOutput(const KUInt8* inBuffer, KUInt32 inSize)
 #endif
 			pa_stream_begin_write(mOutputStream, (void**) &outBuffer, &roomInPAStream);
 			::memcpy(outBuffer, inBuffer, roomInPAStream);
-			pa_stream_write(mOutputStream, outBuffer, inputSize, NULL, 0LL, PA_SEEK_RELATIVE);
-			RaiseOutputInterrupt();
+			pa_stream_write(mOutputStream, outBuffer, roomInPAStream, NULL, 0LL, PA_SEEK_RELATIVE);
+			//RaiseOutputInterrupt();
 		}
 
 		if (inSize < kNewtonBufferSize)
@@ -289,7 +282,6 @@ TPulseAudioSoundManager::ScheduleOutput(const KUInt8* inBuffer, KUInt32 inSize)
 				GetLog()->FLogLine("RAISEOUTPUTINTERRUPT SCHEDULEOUTPUT");
 			}
 #endif
-			RaiseOutputInterrupt();
 		}
 	} else if (mOutputIsRunning)
 	{
@@ -299,8 +291,10 @@ TPulseAudioSoundManager::ScheduleOutput(const KUInt8* inBuffer, KUInt32 inSize)
 			GetLog()->FLogLine("***** FROM NOS: ScheduleOutput no incoming data, STOP Output?");
 		}
 #endif
-		StopOutput();
+		//StopOutput();
 	}
+  RaiseOutputInterrupt();
+
 }
 
 // -------------------------------------------------------------------------- //
@@ -455,7 +449,7 @@ TPulseAudioSoundManager::PAStreamUnderflowCallback(pa_stream* s, pa_threaded_mai
 		GetLog()->FLogLine("   *** PA Underflow occurred!");
 	}
 #endif
-	RaiseOutputInterrupt();
+	//RaiseOutputInterrupt();
 	if (mainloop)
 	{
 		pa_threaded_mainloop_signal(mainloop, 0);

--- a/Emulator/Sound/TPulseAudioSoundManager.cpp
+++ b/Emulator/Sound/TPulseAudioSoundManager.cpp
@@ -285,15 +285,7 @@ TPulseAudioSoundManager::StartOutput(void)
 		{
 			LOG_WITHIN("StartOutput Triggering!");
 		}
-		// while (pa_operation_get_state(mPAOperation) == PA_OPERATION_RUNNING)
-		// {
-		// 	pa_threaded_mainloop_wait(mPAMainLoop);
-		// }
-		// pa_operation_unref(mPAOperation);
 	}
-
-	// mPAOperationDescr = "TRIGGER";
-	// mPAOperation = pa_stream_trigger(mOutputStream, &SPAStreamOpCB, this);
 
 	pa_threaded_mainloop_unlock(mPAMainLoop);
 
@@ -312,24 +304,6 @@ TPulseAudioSoundManager::StopOutput(void)
 
 	mPAOperationDescr = "DRAIN";
 	mPAOperation = pa_stream_drain(mOutputStream, &SPAStreamDrainedCB, this);
-
-	// while (pa_operation_get_state(mPAOperation) == PA_OPERATION_RUNNING)
-	// {
-	// 	pa_threaded_mainloop_wait(mPAMainLoop);
-	// }
-
-	// pa_operation_unref(mPAOperation);
-
-	// mPAOperationDescr = "CORK";
-	// mPAOperation = pa_stream_cork(mOutputStream, 1, &SPAStreamOpCB, this);
-	// pa_operation* corkOp = pa_stream_cork(mOutputStream, 1, NULL, NULL);
-	// pa_operation_unref(corkOp);
-	// while (pa_operation_get_state(mPAOperation) == PA_OPERATION_RUNNING)
-	// {
-	// 	pa_threaded_mainloop_wait(mPAMainLoop);
-	// }
-	//
-	// pa_operation_unref(mPAOperation);
 
 	pa_threaded_mainloop_unlock(mPAMainLoop);
 	LOG_LEAVE("StopOutput");
@@ -373,15 +347,15 @@ TPulseAudioSoundManager::PAStreamWriteCallback(pa_stream* s, unsigned int reques
 		KUIntPtr consumedBytes = mOutputBuffer->Consume(outBuffer, paBufferSize);
 		mDataMutex->Unlock();
 		LOG_WITHIN("WriteCB: Consumed %d bytes from ring buffer", consumedBytes);
-		// FIXME check that these values actually make sense
-		LOG_WITHIN("WriteCB: Writing %d to PA", paBufferSize);
+		paBufferSize = consumedBytes;
+		LOG_WITHIN("WriteCB: Writing %d to PA", consumedBytes);
 
-		pa_stream_write(s, outBuffer, bytesInBuffer, NULL, 0LL, PA_SEEK_RELATIVE);
+		pa_stream_write(s, outBuffer, paBufferSize, NULL, 0LL, PA_SEEK_RELATIVE);
 	} else
 	{
 		LOG_WITHIN("There was no data to write");
 		pa_stream_cancel_write(s);
-		// do we drain and cork here?
+		// do we drain and cork here?  I don't think so.
 		// mPAOperationDescr = "DRAIN";
 		// mPAOperation = pa_stream_drain(s, &SPAStreamDrainedCB, this);
 	}

--- a/Emulator/Sound/TPulseAudioSoundManager.cpp
+++ b/Emulator/Sound/TPulseAudioSoundManager.cpp
@@ -352,18 +352,17 @@ TPulseAudioSoundManager::PAStreamWriteCallback(pa_stream* s, unsigned int reques
 		LOG_WITHIN("WriteCB: Writing %d to PA", consumedBytes);
 
 		pa_stream_write(s, outBuffer, paBufferSize, NULL, 0LL, PA_SEEK_RELATIVE);
-	}
-  else
+	} else
 	{
 		LOG_WITHIN("There was no data to write");
 		pa_stream_cancel_write(s);
 		// do we drain and cork here?  I don't think so.
 	}
-  // do we raise output interrupt here instead of in ScheduleOutput?
-  // if (bytesInBuffer < kNewtonBufferSize)
-  // {
-  //   RaiseOutputInterrupt();
-  // }
+	// do we raise output interrupt here instead of in ScheduleOutput?
+	// if (bytesInBuffer < kNewtonBufferSize)
+	// {
+	//   RaiseOutputInterrupt();
+	// }
 	LOG_LEAVE("Stream write callback");
 }
 

--- a/Emulator/Sound/TPulseAudioSoundManager.h
+++ b/Emulator/Sound/TPulseAudioSoundManager.h
@@ -84,6 +84,14 @@ public:
 	///
 	void OutputVolumeChanged(void) override;
 
+protected:
+	static void
+	SPASafeUnrefOp(pa_operation* op)
+	{
+		if (op)
+			pa_operation_unref(op);
+	}
+
 private:
 	// callback routines (static).  PulseAudio lets us pass an arbitrary void pointer to callback functions.
 	// When callback function pointer is given to PulseAudio, we give a pointer to the class instance (this) as userData.

--- a/Emulator/Sound/TPulseAudioSoundManager.h
+++ b/Emulator/Sound/TPulseAudioSoundManager.h
@@ -134,7 +134,7 @@ private:
 	static void
 	SPAStreamDrainedCB(pa_stream* stream, int success, void* userData)
 	{
-		return ((TPulseAudioSoundManager*) userData)->PAStreamOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
+		return ((TPulseAudioSoundManager*) userData)->PAStreamDrainedCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
 	}
 	void PAStreamDrainedCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
 

--- a/Emulator/Sound/TPulseAudioSoundManager.h
+++ b/Emulator/Sound/TPulseAudioSoundManager.h
@@ -35,6 +35,7 @@
 #include "TBufferedSoundManager.h"
 
 class TMutex;
+class TCircleBuffer;
 
 ///
 /// Class to handle sound input/output and direct them to PulseAudio.
@@ -110,10 +111,8 @@ private:
 	}
 
 	void PAContextStateCallback(pa_context* context, pa_threaded_mainloop* mainloop);
-
 	void PAStreamStateCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
 	void PAStreamUnderflowCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
-
 	void PAStreamWriteCallback(pa_stream* s, unsigned int requested_bytes);
 
 	static void
@@ -133,11 +132,11 @@ private:
 	/// \name Variables
 	pa_operation* mPAOperation;
 	char const* mPAOperationDescr;
+  TCircleBuffer* mOutputBuffer;
+  TMutex* mDataMutex;
 	pa_stream* mOutputStream;
 	pa_threaded_mainloop* mPAMainLoop;
-	pa_mainloop_api* mPAMainLoopAPI;
 	pa_context* mPAContext;
-	TMutex* mDataMutex;
 	Boolean mOutputIsRunning;
 };
 

--- a/Emulator/Sound/TPulseAudioSoundManager.h
+++ b/Emulator/Sound/TPulseAudioSoundManager.h
@@ -85,49 +85,66 @@ public:
 	void OutputVolumeChanged(void) override;
 
 private:
-	// callback routines (static)
+	// callback routines (static).  PulseAudio lets us pass an arbitrary void pointer to callback functions.
+  // When callback function pointer is given to PulseAudio, we give a pointer to the class instance (this) as userData.
+  // Then in the static functions here, userData is used to call the class function
+  // defined in the .cpp file.  That function receives a pointer to the PA mainloop, NOT the original UserData!
+
+  // Context state change callback
 	static void
 	SPAContextStateCallback(pa_context* context, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAContextStateCallback(context, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
 	}
+  void PAContextStateCallback(pa_context* context, pa_threaded_mainloop* mainloop);
 
-	static void
-	SPAStreamStateCallback(pa_stream* s, void* userData)
+  // Stream state change callback
+	static void SPAStreamStateCallback(pa_stream* s, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAStreamStateCallback(s, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
 	}
+  void PAStreamStateCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
 
-	static void
-	SPAStreamUnderflowCallback(pa_stream* s, void* userData)
+  // Stream Underflow event callback.
+	static void SPAStreamUnderflowCallback(pa_stream* s, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAStreamUnderflowCallback(s, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
 	}
+  void PAStreamUnderflowCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
 
-	static void
-	SPAStreamWriteCallback(pa_stream* s, size_t requested_bytes, void* userData)
+  // Stream write callback - called when PulseAudio wants us to write to the stream.
+	static void SPAStreamWriteCallback(pa_stream* s, size_t requested_bytes, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAStreamWriteCallback(s, (unsigned) requested_bytes);
 	}
-
-	void PAContextStateCallback(pa_context* context, pa_threaded_mainloop* mainloop);
-	void PAStreamStateCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
-	void PAStreamUnderflowCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
 	void PAStreamWriteCallback(pa_stream* s, unsigned int requested_bytes);
 
-	static void
-	SPAStreamOpCB(pa_stream* stream, int success, void* userData)
+  // Generic stream  operation callback function.
+	static void SPAStreamOpCB(pa_stream* stream, int success, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAStreamOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
 	}
-
 	void PAStreamOpCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
 
-	static void
-	PAStreamSuccessCallback(pa_stream* stream, int success, void* userData)
-	{
-		return pa_threaded_mainloop_signal((pa_threaded_mainloop*) userData, 0);
-	}
+  // Stream Drain operation callback.  Called when PA has played everything in the buffer.
+  static void SPAStreamDrainedCB(pa_stream* stream, int success, void* userData)
+  {
+    return ((TPulseAudioSoundManager*) userData)->PAStreamOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
+  }
+  void PAStreamDrainedCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
+
+  // Post-uncork operation callback.  Trigger immediate output.
+  static void SPATriggerAfterOpCB(pa_stream* stream, int success, void* userData)
+  {
+    return ((TPulseAudioSoundManager*) userData)->PATriggerAfterOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
+  }
+  void PATriggerAfterOpCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
+
+
+	// static void PAStreamSuccessCallback(pa_stream* stream, int success, void* userData)
+	// {
+	// 	return pa_threaded_mainloop_signal((pa_threaded_mainloop*) userData, 0);
+	// }
 
 	/// \name Variables
 	pa_operation* mPAOperation;

--- a/Emulator/Sound/TPulseAudioSoundManager.h
+++ b/Emulator/Sound/TPulseAudioSoundManager.h
@@ -86,59 +86,65 @@ public:
 
 private:
 	// callback routines (static).  PulseAudio lets us pass an arbitrary void pointer to callback functions.
-  // When callback function pointer is given to PulseAudio, we give a pointer to the class instance (this) as userData.
-  // Then in the static functions here, userData is used to call the class function
-  // defined in the .cpp file.  That function receives a pointer to the PA mainloop, NOT the original UserData!
+	// When callback function pointer is given to PulseAudio, we give a pointer to the class instance (this) as userData.
+	// Then in the static functions here, userData is used to call the class function
+	// defined in the .cpp file.  That function receives a pointer to the PA mainloop, NOT the original UserData!
 
-  // Context state change callback
+	// Context state change callback
 	static void
 	SPAContextStateCallback(pa_context* context, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAContextStateCallback(context, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
 	}
-  void PAContextStateCallback(pa_context* context, pa_threaded_mainloop* mainloop);
+	void PAContextStateCallback(pa_context* context, pa_threaded_mainloop* mainloop);
 
-  // Stream state change callback
-	static void SPAStreamStateCallback(pa_stream* s, void* userData)
+	// Stream state change callback
+	static void
+	SPAStreamStateCallback(pa_stream* s, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAStreamStateCallback(s, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
 	}
-  void PAStreamStateCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
+	void PAStreamStateCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
 
-  // Stream Underflow event callback.
-	static void SPAStreamUnderflowCallback(pa_stream* s, void* userData)
+	// Stream Underflow event callback.
+	static void
+	SPAStreamUnderflowCallback(pa_stream* s, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAStreamUnderflowCallback(s, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
 	}
-  void PAStreamUnderflowCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
+	void PAStreamUnderflowCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
 
-  // Stream write callback - called when PulseAudio wants us to write to the stream.
-	static void SPAStreamWriteCallback(pa_stream* s, size_t requested_bytes, void* userData)
+	// Stream write callback - called when PulseAudio wants us to write to the stream.
+	static void
+	SPAStreamWriteCallback(pa_stream* s, size_t requested_bytes, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAStreamWriteCallback(s, (unsigned) requested_bytes);
 	}
 	void PAStreamWriteCallback(pa_stream* s, unsigned int requested_bytes);
 
-  // Generic stream  operation callback function.
-	static void SPAStreamOpCB(pa_stream* stream, int success, void* userData)
+	// Generic stream  operation callback function.
+	static void
+	SPAStreamOpCB(pa_stream* stream, int success, void* userData)
 	{
 		return ((TPulseAudioSoundManager*) userData)->PAStreamOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
 	}
 	void PAStreamOpCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
 
-  // Stream Drain operation callback.  Called when PA has played everything in the buffer.
-  static void SPAStreamDrainedCB(pa_stream* stream, int success, void* userData)
-  {
-    return ((TPulseAudioSoundManager*) userData)->PAStreamOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
-  }
-  void PAStreamDrainedCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
+	// Stream Drain operation callback.  Called when PA has played everything in the buffer.
+	static void
+	SPAStreamDrainedCB(pa_stream* stream, int success, void* userData)
+	{
+		return ((TPulseAudioSoundManager*) userData)->PAStreamOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
+	}
+	void PAStreamDrainedCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
 
-  // Post-uncork operation callback.  Trigger immediate output.
-  static void SPATriggerAfterOpCB(pa_stream* stream, int success, void* userData)
-  {
-    return ((TPulseAudioSoundManager*) userData)->PATriggerAfterOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
-  }
-  void PATriggerAfterOpCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
+	// Post-uncork operation callback.  Trigger immediate output.
+	static void
+	SPATriggerAfterOpCB(pa_stream* stream, int success, void* userData)
+	{
+		return ((TPulseAudioSoundManager*) userData)->PATriggerAfterOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
+	}
+	void PATriggerAfterOpCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
 
 	// static void PAStreamSuccessCallback(pa_stream* stream, int success, void* userData)
 	// {
@@ -148,8 +154,8 @@ private:
 	/// \name Variables
 	pa_operation* mPAOperation;
 	char const* mPAOperationDescr;
-  TCircleBuffer* mOutputBuffer;
-  TMutex* mDataMutex;
+	TCircleBuffer* mOutputBuffer;
+	TMutex* mDataMutex;
 	pa_stream* mOutputStream;
 	pa_threaded_mainloop* mPAMainLoop;
 	pa_context* mPAContext;

--- a/Emulator/Sound/TPulseAudioSoundManager.h
+++ b/Emulator/Sound/TPulseAudioSoundManager.h
@@ -60,7 +60,7 @@ public:
 	~TPulseAudioSoundManager(void) override;
 
 	///
-	/// Schedule output of some buffer.
+	/// Schedule output of some buffer. Called when NewtonOS has sounds to play.
 	///
 	void ScheduleOutput(const KUInt8* inBufferAddr, KUInt32 inSize) override;
 
@@ -73,11 +73,6 @@ public:
 	/// Stop output.
 	///
 	void StopOutput(void) override;
-
-	///
-	/// Is output running?
-	///
-	Boolean OutputIsRunning(void) override;
 
 	///
 	/// Method called to signal a change in the output volume.
@@ -154,7 +149,6 @@ private:
 	pa_stream* mOutputStream;
 	pa_threaded_mainloop* mPAMainLoop;
 	pa_context* mPAContext;
-	Boolean mOutputIsRunning;
 };
 
 #endif

--- a/Emulator/Sound/TPulseAudioSoundManager.h
+++ b/Emulator/Sound/TPulseAudioSoundManager.h
@@ -70,6 +70,11 @@ public:
 	void StartOutput(void) override;
 
 	///
+	/// Is output running?
+	///
+	Boolean OutputIsRunning(void) override;
+
+	///
 	/// Stop output.
 	///
 	void StopOutput(void) override;
@@ -134,7 +139,6 @@ private:
     return ((TPulseAudioSoundManager*) userData)->PATriggerAfterOpCB(stream, success, ((TPulseAudioSoundManager*) userData)->mPAMainLoop);
   }
   void PATriggerAfterOpCB(pa_stream* s, int success, pa_threaded_mainloop* mainloop);
-
 
 	// static void PAStreamSuccessCallback(pa_stream* stream, int success, void* userData)
 	// {


### PR DESCRIPTION
I swear this was working fine in 2018, but I recently discovered that TPulseAudioSoundManager had terrible, clicking output, and was also slowing down the emulation by at least 5-10x - on my Intel Core i7-8665U.  PulseAudio would not stop polling for writes, and the interruptions were causing the severe slowdown.

This fixes the clicking output and the performance hit.  It's still not perfect - the startup sound gets cut off, for example - but it's a vast improvement for sure.