### PR TITLE
Accept sharesheet interface on iOS to install packages.

### DIFF
--- a/Resources/iOSEinstein Storyboards-Info.plist
+++ b/Resources/iOSEinstein Storyboards-Info.plist
@@ -6,6 +6,19 @@
 	<string>English</string>
 	<key>CFBundleDisplayName</key>
 	<string>iOSEinstein</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Newton Package Data</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.newton-inc.pkg</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>iOSEinstein</string>
 	<key>CFBundleIconFile</key>
@@ -31,6 +44,8 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
@@ -47,6 +62,30 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Newton Package Data</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.newton-inc.pkg</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pkg</string>
+					<string>PKG</string>
+					<string>newtonpkg</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/app/iEinstein/Classes/iEinsteinAppDelegate.mm
+++ b/app/iEinstein/Classes/iEinsteinAppDelegate.mm
@@ -88,6 +88,53 @@
 	return YES;
 }
 
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+	if ([url.scheme isEqualToString:@"file"]) {
+		[url startAccessingSecurityScopedResource];
+		NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+		NSString *documentsDirectory = [paths objectAtIndex:0];
+		NSString *srcPath = url.path;
+		NSString *filename = [srcPath lastPathComponent];
+		NSString *dstPath = [documentsDirectory stringByAppendingPathComponent:filename];
+		NSError *error = nil;
+		
+		if(![srcPath isEqualToString:dstPath]) {
+			if ([[NSFileManager defaultManager] fileExistsAtPath:dstPath]) {
+				[[NSFileManager defaultManager] removeItemAtPath:dstPath error:&error];
+				if(error){
+					NSLog(@"%@ %ld %@",[error domain],(long)[error code],[[error userInfo] description]);
+				}
+				else{
+					NSLog(@"File removed.");
+				}
+			}
+			[[NSFileManager defaultManager] copyItemAtPath:srcPath toPath:dstPath error:&error];
+		}
+		
+		if(error){
+			 NSLog(@"%@ %ld %@",[error domain],(long)[error code],[[error userInfo] description]);
+		}
+		else {
+			NSLog(@"Pkg File copied.");
+			[viewController installNewPackages];
+			[[NSFileManager defaultManager] removeItemAtPath:dstPath error:&error];
+			if(error){
+				NSLog(@"%@ %ld %@",[error domain],(long)[error code],[[error userInfo] description]);
+			}
+			else{
+				NSLog(@"Installed Pkg file removed.");
+			}
+		}
+		return YES;
+	}
+	else {
+		 [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:{}];
+		return YES;
+	}
+	return NO;
+}
+
 - (void)applicationWillResignActive:(UIApplication*)application
 {
 	[viewController stopEmulator];

--- a/app/iEinstein/Classes/iEinsteinViewController.mm
+++ b/app/iEinstein/Classes/iEinsteinViewController.mm
@@ -41,6 +41,20 @@ iEinsteinViewController ()
 
 @implementation iEinsteinViewController
 
+- (void)viewDidLoad
+{
+	[super viewDidLoad];
+
+	NSFileManager *fm = [NSFileManager defaultManager];
+	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,NSUserDomainMask, YES);
+	NSString *DocumentsDirPath = [paths objectAtIndex:0];
+	
+	NSString *filePath = [DocumentsDirPath stringByAppendingPathComponent:@".showFolder.txt"];
+	if(![fm fileExistsAtPath:filePath]) {
+		[fm createFileAtPath:filePath contents:nil attributes:nil];
+	}
+}
+
 - (void)viewWillAppear:(BOOL)animated
 {
 	[super viewWillAppear:animated];


### PR DESCRIPTION
Hello,
This is some modification for iOS.
You can now Install newton package (*.pkg, *.PKG, *.newtonpkg) from:
 - File.app
 - Mail.app(enclosed pkg)
 - ShareSheet from any other app

No need to use iTunes file sharing any more.