### PR TITLE
Fix the Settings bundle on iOS 18+

### DIFF
--- a/app/iEinstein/Settings.bundle/Root.plist
+++ b/app/iEinstein/Settings.bundle/Root.plist
@@ -10,15 +10,9 @@
 	<array>
 		<dict>
 			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-			<key>Title</key>
-			<string>Screen Settings</string>
-		</dict>
-		<dict>
-			<key>Type</key>
 			<string>PSMultiValueSpecifier</string>
 			<key>Title</key>
-			<string>Resolution</string>
+			<string>Screen Resolution</string>
 			<key>Key</key>
 			<string>screen_resolution</string>
 			<key>DefaultValue</key>
@@ -77,14 +71,6 @@
 				<string>{8,9.88897}</string>
 				<string>{7.76771,10.58188}</string>
 			</array>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSTextFieldSpecifier</string>
-			<key>Title</key>
-			<string></string>
-			<key>Key</key>
-			<string></string>
 		</dict>
 		<dict>
 			<key>Type</key>


### PR DESCRIPTION
It seems that in iOS 18, empty `Key` values for `PSTextFieldSpecifier` will cause the Settings bundle not to load, instead of being ignored. I don't know if this is documented anywhere or if Apple simply made parsing more strict in iOS 18.

Either way, this fixes #191 and restores the Settings bundle for the iOS app:

<img width="1170" height="2532" alt="simulator_screenshot_CFC3EE59-0193-462C-9903-D8F78A9499FC" src="https://github.com/user-attachments/assets/6df232d9-b7a3-4aa7-9659-c7179680da0f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Settings Updates**
  * Improved settings label clarity for screen resolution
  * Removed unused preference sections and empty fields from the app settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->