### PR TITLE
Allow file loading (including ROMs and pkgs) from Files app and share sheet

### DIFF
--- a/Resources/iOSEinstein Storyboards-Info.plist
+++ b/Resources/iOSEinstein Storyboards-Info.plist
@@ -8,6 +8,29 @@
 	<string>iOSEinstein</string>
 	<key>CFBundleExecutable</key>
 	<string>iOSEinstein</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Newton Package Data</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.newton-inc.pkg</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Newton ROM Image</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.newton-inc.rom</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
@@ -31,7 +54,11 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>UISupportsDocumentBrowser</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
@@ -47,6 +74,50 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Newton Package Data</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.newton-inc.pkg</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pkg</string>
+					<string>PKG</string>
+					<string>newtonpkg</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Newton ROM Image</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.newton-inc.rom</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>rom</string>
+					<string>ROM</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Resources/iOSEinstein-Info.plist
+++ b/Resources/iOSEinstein-Info.plist
@@ -33,7 +33,11 @@
 	<string>MainWindow</string>
 	<key>NSMainNibFile~ipad</key>
 	<string>MainWindow_iPad</string>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>UISupportsDocumentBrowser</key>
 	<true/>
 	<key>UIStatusBarHidden</key>
 	<false/>

--- a/app/iEinstein/Classes/iEinsteinViewController.h
+++ b/app/iEinstein/Classes/iEinsteinViewController.h
@@ -47,6 +47,7 @@ class TLog;
 	TPlatformManager* mPlatformManager;
 	TLog* mLog;
 	int lastKnownScreenResolution;
+	UIAlertView* mMissingROMAlertView;
 }
 
 @property (retain, nonatomic) IBOutlet iEinsteinView* einsteinView;
@@ -95,6 +96,7 @@ class TLog;
 
 - (void)verifyDeleteFlashRAM:(int)withTag;
 - (void)explainMissingROM;
+- (BOOL)checkForROMImage;
 //- (void)openEinsteinMenu;
 
 - (int)allResourcesFound;


### PR DESCRIPTION
(This PR builds on (and supercedes) awesome work done by @AlohaYos in PR #189. 🤝)

This PR adds iOS file sharing support and removes the need to plug your device into your Mac. Users can now import the all-important `.rom` file and additional `.pkg` files via the iOS share sheet or the Files app (which now shows `iOSEinstein`'s Documents folder within the "On My iPhone" section).

I shuffled around the ROM loading a bit so that we can detect the ROM at any point in the app lifecycle (so the "Quit Einstein" alert will dismiss if the user didn't press the button but instead went to go load a ROM... which I did a number of times 😆).

Fixes #48.

<img width="250" style="float: left" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-13 at 15 47 35" src="https://github.com/user-attachments/assets/c9ecc402-b112-4caa-9eb3-25b62cc93fcf" />
<img width="250" style="float: left"  alt="Screenshot 2025-12-13 at 3 48 26 PM" src="https://github.com/user-attachments/assets/7b0117cd-f603-4742-9515-d22d7e54c202" />
<img width="250" style="float: left"   alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-13 at 15 47 13" src="https://github.com/user-attachments/assets/5768e653-baf9-4179-ac41-be2771551557" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening Newton Package Data and ROM Image files directly from Files app.
  * Enabled document browser integration for easier file management.
  * Improved ROM image detection and handling during app launch and resume.

* **Bug Fixes**
  * Enhanced error handling for missing ROM files with clearer user alerts.
  * Refined file processing workflow for better stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->