### PR TITLE
s/SIze/Size/g

### DIFF
--- a/Emulator/Platform/TPlatformManager.cpp
+++ b/Emulator/Platform/TPlatformManager.cpp
@@ -674,7 +674,7 @@ TPlatformManager::EvalNewtonScript(const char* inNewtonScriptCode)
 }
 
 // -------------------------------------------------------------------------- //
-//  * InstallPackage(const KUInt8* inPackageData, KUInt32 inPackageSIze)
+//  * InstallPackage(const KUInt8* inPackageData, KUInt32 inPackageSize)
 // -------------------------------------------------------------------------- //
 void
 TPlatformManager::InstallPackage(const KUInt8* inPackageData, KUInt32 inPackageSize)

--- a/app/FLTK/TFLAppUI.fl
+++ b/app/FLTK/TFLAppUI.fl
@@ -173,7 +173,7 @@ Function {CreateApplicationWindow(int x, int y)} {open
         xywh {0 0 100 20}
       } {
         MenuItem {} {
-          label {Initial SIze}
+          label {Initial Size}
           callback {gApp->UserActionOriginalScreenSize();}
           xywh {0 0 100 20}
         }


### PR DESCRIPTION
I got low-grade bothered seeing `SIze` in FLTK and on Windows, so I decided to fix it.

<img width="346" height="308" alt="Screenshot 2025-12-18 at 1 14 07 AM" src="https://github.com/user-attachments/assets/1c06dc2a-eeb8-49a8-88c8-f104a95033fa" />

I'm not sure what to make of the CI failures. Some of them were due to 404ing Ubuntu packages, while others had timeouts that I'm not familiar with (unlike, say, 20-minute timeouts imposed by GitHub).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed typo in menu item label for improved clarity.

* **Documentation**
  * Corrected typo in documentation comment for parameter naming consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->