### PR TITLE
Einstein: port to FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
 
 	# Linux: nothing to do here
 
+elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD" OR ${CMAKE_SYSTEM_NAME} STREQUAL "NetBSD" )
+
+    # FreeBSD and NetBSD: nothing to do here
+
 elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" )
 
 	set_property ( GLOBAL PROPERTY FIND_LIBRARY_USE_OPENBSD_VERSIONING 1 )
@@ -422,7 +426,7 @@ if ( ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" )
 		)
 	endif ()
 
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" )
+elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD$" )
 
 	# create the application
 	add_executable ( Einstein
@@ -442,17 +446,22 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL 
 	# how to compile and link
 	target_compile_options ( Einstein PUBLIC
 		-Wall -Wno-multichar -Wno-misleading-indentation -Wno-unused-result
-		-Wno-missing-field-initializers -Wno-stringop-truncation # -Werror
+		-Wno-missing-field-initializers # -Werror
 		# Werror is disabled for testing purposes. Must reenable as soon as all Linux warnings are fixed.
 	)
 	target_compile_options ( EinsteinTests PUBLIC
 		-Wall -Wno-multichar -Wno-misleading-indentation -Wno-unused-result
-		-Wno-missing-field-initializers -Wno-stringop-truncation -Werror
+		-Wno-missing-field-initializers -Werror
 	)
 	target_compile_options ( EinsteinFLGUI PUBLIC
 		-Wall -Wno-multichar -Wno-misleading-indentation -Wno-unused-result
-		-Wno-missing-field-initializers -Wno-stringop-truncation -Werror
+		-Wno-missing-field-initializers -Werror
 	)
+	if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(Einstein PUBLIC -Wno-stringop-truncation)
+        target_compile_options(EinsteinTests PUBLIC -Wno-stringop-truncation)
+        target_compile_options(EinsteinFLGUI PUBLIC -Wno-stringop-truncation)
+    endif()
 	target_compile_definitions ( Einstein PRIVATE
 		TARGET_UI_FLTK=1 TARGET_OS_LINUX=1
 	)
@@ -478,8 +487,8 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL 
 		fltk::fltk fltk::images fltk::png fltk::z
 	)
 
-	if ( ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" )
-		# Under OpenBSD, libffi is in ports (i.e. /usr/local) not base (i.e. /usr)
+	if ( ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD$" )
+		# Under BSD, libffi is in ports (i.e. /usr/local) not base (i.e. /usr)
 		find_library ( ffi_lib NAMES ffi )
 		find_file ( ffi_incl NAMES ffi.h )
 		if ( ffi_lib MATCHES ".*NOTFOUND" OR ffi_incl MATCHES ".*NOTFOUND" )
@@ -492,7 +501,7 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL 
 			target_link_libraries ( Einstein ${ffi_lib} )
 		endif ()
 
-		# Under OpenBSD, pulseaudio is in ports (i.e. /usr/local) not base (i.e. /usr)
+		# Under BSD, pulseaudio is in ports (i.e. /usr/local) not base (i.e. /usr)
 		find_library ( pulse_lib NAMES pulse )
 		if ( pulse_lib MATCHES ".*NOTFOUND" )
 			message ( FATAL_ERROR "libpulse not found! " )
@@ -502,7 +511,7 @@ elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL 
 			target_link_libraries ( Einstein ${pulse_lib} )
 		endif ()
 
-		# Under OpenBSD, X11 is in /usr/X11R6
+		# Under BSD, find X11
 		include ( FindX11 )
 		if ( X11_FOUND )
 			target_include_directories ( Einstein SYSTEM PUBLIC ${X11_INCLUDE_DIR} )
@@ -681,7 +690,7 @@ configure_file (
 #
 
 find_program(CLANG_FORMAT_EXECUTABLE
-    NAMES clang-format-14 clang-format-mp-14 clang-format
+    NAMES clang-format-14 clang-format-mp-14 clang-format19 clang-format
     HINTS /usr/local/opt/clang-format@14/bin/ /usr/lib/llvm-14/bin/
     DOC "clang-format executable")
 if(CLANG_FORMAT_EXECUTABLE)

--- a/Emulator/NativeCalls/CMakeLists.txt
+++ b/Emulator/NativeCalls/CMakeLists.txt
@@ -18,7 +18,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 		Emulator/NativeCalls/TObjCBridgeCalls.mm
 		Emulator/NativeCalls/TObjCBridgeCalls.h
 	)
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD$")
 	list (APPEND common_sources
 			Emulator/NativeCalls/NativeCallsDefines.h
 			Emulator/NativeCalls/TNativeCalls.cpp

--- a/Emulator/Serial/CMakeLists.txt
+++ b/Emulator/Serial/CMakeLists.txt
@@ -31,7 +31,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 		Emulator/Serial/TPtySerialPortManager.cpp
 		Emulator/Serial/TPtySerialPortManager.h
 	)
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD$")
 	list (APPEND common_sources
 		Emulator/Serial/TSerialHostPort.h
 		Emulator/Serial/TSerialHostPortDirect.h

--- a/Emulator/Sound/CMakeLists.txt
+++ b/Emulator/Sound/CMakeLists.txt
@@ -20,7 +20,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 		Emulator/Sound/TCoreAudioSoundManager.cpp
 		Emulator/Sound/TCoreAudioSoundManager.h
 	)
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD$")
 	list (APPEND app_sources
 		Emulator/Sound/TPulseAudioSoundManager.cpp
 		Emulator/Sound/TPulseAudioSoundManager.h


### PR DESCRIPTION
Port Einstein to FreeBSD
While there, handle NetBSD
Don't break existing Linux and OpenBSD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PulseAudio-backed sound output by buffering audio and scheduling writes more reliably.
* **Chores**
  * Enhanced cross-platform BSD handling in the build system with more accurate system detection and consistent source/dependency selection across BSD variants.
  * Updated GNU compiler warning flag behavior and expanded clang-format discovery to support additional versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the CMake build paths toward FreeBSD and NetBSD support. The main changes are:

- FreeBSD and NetBSD system-name handling in the top-level build.
- BSD source selection for native calls, serial, and PulseAudio sound.
- BSD dependency lookup for ffi, PulseAudio, and X11.
- Compiler warning and clang-format discovery updates.

<h3>Confidence Score: 4/5</h3>

This should be fixed before merging.

- Mixed C/C++ compiler builds can still pass a GCC-only warning flag to Clang C++ targets.
- FreeBSD and NetBSD builds still receive the Linux platform macro and can take Linux-only header paths.

CMakeLists.txt

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CMakeLists.txt | Updates the main platform branch, dependency lookup, compiler flags, and formatter discovery. |
| Emulator/NativeCalls/CMakeLists.txt | Expands native-call source selection from OpenBSD to BSD variants. |
| Emulator/Serial/CMakeLists.txt | Expands serial source selection from OpenBSD to BSD variants. |
| Emulator/Sound/CMakeLists.txt | Expands PulseAudio sound source selection from OpenBSD to BSD variants. |

<sub>Reviews (3): Last reviewed commit: ["Einstein: port to FreeBSD"](https://github.com/pguyot/einstein/commit/2bfd5f01778db29d7eb48c171abd1abd8950b146) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33641631)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->