### PR TITLE
Fix Pulseaudio buffering

### DIFF
--- a/Emulator/Sound/TPulseAudioSoundManager.cpp
+++ b/Emulator/Sound/TPulseAudioSoundManager.cpp
@@ -491,7 +491,7 @@ TPulseAudioSoundManager::PAStreamWriteQueuedOutput(pa_stream* s, size_t requeste
 {
 	void* outBuffer = NULL;
 	size_t bytesToWrite = requested_bytes;
-	KUIntPtr bytesConsumed;
+	KUIntPtr bytesCopied;
 
 	if (bytesToWrite == 0)
 	{
@@ -517,20 +517,13 @@ TPulseAudioSoundManager::PAStreamWriteQueuedOutput(pa_stream* s, size_t requeste
 
 	if (pa_stream_begin_write(s, &outBuffer, &bytesToWrite) < 0)
 	{
+		if (requestMoreOutput)
+		{
+			RequestOutputInterrupt();
+		}
 		return;
 	}
 	if (outBuffer == NULL || bytesToWrite == 0)
-	{
-		pa_stream_cancel_write(s);
-		return;
-	}
-
-	mDataMutex->Lock();
-	bytesConsumed = mOutputBuffer->Consume(outBuffer, bytesToWrite);
-	KUIntPtr bytesLeft = mOutputBuffer->AvailableBytes();
-	mDataMutex->Unlock();
-
-	if (bytesConsumed == 0)
 	{
 		pa_stream_cancel_write(s);
 		if (requestMoreOutput)
@@ -540,7 +533,33 @@ TPulseAudioSoundManager::PAStreamWriteQueuedOutput(pa_stream* s, size_t requeste
 		return;
 	}
 
-	pa_stream_write(s, outBuffer, bytesConsumed, NULL, 0LL, PA_SEEK_RELATIVE);
+	mDataMutex->Lock();
+	bytesCopied = mOutputBuffer->Peek(outBuffer, bytesToWrite);
+	mDataMutex->Unlock();
+
+	if (bytesCopied == 0)
+	{
+		pa_stream_cancel_write(s);
+		if (requestMoreOutput)
+		{
+			RequestOutputInterrupt();
+		}
+		return;
+	}
+
+	if (pa_stream_write(s, outBuffer, bytesCopied, NULL, 0LL, PA_SEEK_RELATIVE) < 0)
+	{
+		if (requestMoreOutput)
+		{
+			RequestOutputInterrupt();
+		}
+		return;
+	}
+
+	mDataMutex->Lock();
+	mOutputBuffer->Discard(bytesCopied);
+	KUIntPtr bytesLeft = mOutputBuffer->AvailableBytes();
+	mDataMutex->Unlock();
 
 	if (requestMoreOutput && bytesLeft < kNewtonBufferSize)
 	{

--- a/Emulator/Sound/TPulseAudioSoundManager.cpp
+++ b/Emulator/Sound/TPulseAudioSoundManager.cpp
@@ -36,6 +36,7 @@
 #include <unistd.h>
 
 // K
+#include <K/Misc/TCircleBuffer.h>
 #include <K/Threads/TMutex.h>
 
 // Einstein.
@@ -55,8 +56,11 @@
 // -------------------------------------------------------------------------- //
 TPulseAudioSoundManager::TPulseAudioSoundManager(TLog* inLog /* = nil */) :
 		TBufferedSoundManager(inLog),
+		mOutputBuffer(new TCircleBuffer(
+			kNewtonBufferSizeInFrames * 4 * sizeof(KUInt16))),
 		mDataMutex(new TMutex()),
-		mOutputIsRunning(false)
+		mOutputIsRunning(false),
+		mOutputRequestPending(false)
 {
 	int result = 0;
 	int stream_flags = 0;
@@ -130,8 +134,7 @@ TPulseAudioSoundManager::TPulseAudioSoundManager(TLog* inLog /* = nil */) :
 
 	mOutputStream = pa_stream_new(mPAContext, "Playback", &outputParameters, &channelMap);
 	pa_stream_set_state_callback(mOutputStream, &SPAStreamStateCallback, this);
-	// NO WRITE CALLBACK - we do writes to PulseAudio immediately upon receiving data from the Newton
-	// pa_stream_set_write_callback(mOutputStream, &SPAStreamWriteCallback, this);
+	pa_stream_set_write_callback(mOutputStream, &SPAStreamWriteCallback, this);
 	pa_stream_set_underflow_callback(mOutputStream, &SPAStreamUnderflowCallback, this);
 
 	pa_buffer_attr buffer_attr;
@@ -163,6 +166,7 @@ TPulseAudioSoundManager::TPulseAudioSoundManager(TLog* inLog /* = nil */) :
 				"PulseAudio stream did not connect with pa_stream_connect_playback (%s)",
 				pa_strerror(result));
 		}
+		pa_threaded_mainloop_unlock(mPAMainLoop);
 		return;
 	}
 
@@ -225,16 +229,36 @@ TPulseAudioSoundManager::~TPulseAudioSoundManager(void)
 {
 	if (mOutputStream)
 	{
+		if (mPAMainLoop)
+		{
+			pa_threaded_mainloop_lock(mPAMainLoop);
+		}
+		pa_stream_set_write_callback(mOutputStream, NULL, NULL);
+		pa_stream_set_underflow_callback(mOutputStream, NULL, NULL);
+		pa_stream_set_state_callback(mOutputStream, NULL, NULL);
 		// disconnect the stream
 		pa_stream_disconnect(mOutputStream);
-		pa_context_disconnect(mPAContext);
-		// pa_threaded_mainloop_stop
+		if (mPAContext)
+		{
+			pa_context_disconnect(mPAContext);
+		}
+		if (mPAMainLoop)
+		{
+			pa_threaded_mainloop_unlock(mPAMainLoop);
+		}
+	}
+	if (mPAMainLoop)
+	{
 		pa_threaded_mainloop_stop(mPAMainLoop);
 		pa_threaded_mainloop_free(mPAMainLoop);
 	}
 	if (mDataMutex)
 	{
 		delete mDataMutex;
+	}
+	if (mOutputBuffer)
+	{
+		delete mOutputBuffer;
 	}
 }
 
@@ -246,51 +270,21 @@ TPulseAudioSoundManager::ScheduleOutput(const KUInt8* inBuffer, KUInt32 inSize)
 {
 	if (inSize > 0)
 	{
-		size_t inputSize = inSize;
-		size_t roomInPAStream = pa_stream_writable_size(mOutputStream);
-		KUInt8* outBuffer = NULL;
 #ifdef DEBUG_SOUND
 		if (GetLog())
 		{
-			GetLog()->FLogLine("***** FROM NOS: ScheduleOutput size:%d, frames:%ld, PA out buffer size:%d",
-				inputSize, (inSize / sizeof(KSInt16)), roomInPAStream);
+			GetLog()->FLogLine("***** FROM NOS: ScheduleOutput size:%d, frames:%ld",
+				inSize, (inSize / sizeof(KSInt16)));
 		}
 #endif
-		if (roomInPAStream >= inputSize)
-		{
-#ifdef DEBUG_SOUND
-			if (GetLog())
-			{
-				GetLog()->FLogLine("***** FROM NOS: ScheduleOutput writing %d to PulseAudio (lots of space)", inputSize);
-			}
-#endif
-			pa_stream_begin_write(mOutputStream, (void**) &outBuffer, &inputSize);
-			::memcpy(outBuffer, inBuffer, inputSize);
-			pa_stream_write(mOutputStream, outBuffer, inputSize, NULL, 0LL, PA_SEEK_RELATIVE);
-		} else
-		{
-#ifdef DEBUG_SOUND
-			if (GetLog())
-			{
-				GetLog()->FLogLine("***** FROM NOS: ScheduleOutput writing %d to PulseAudio (LACK of space) - RAISEOUTPUTINTERRUPT SCHEDULEOUTPUT", roomInPAStream);
-			}
-#endif
-			pa_stream_begin_write(mOutputStream, (void**) &outBuffer, &roomInPAStream);
-			::memcpy(outBuffer, inBuffer, roomInPAStream);
-			pa_stream_write(mOutputStream, outBuffer, inputSize, NULL, 0LL, PA_SEEK_RELATIVE);
-			RaiseOutputInterrupt();
-		}
+		mDataMutex->Lock();
+		mOutputBuffer->Produce(inBuffer, inSize);
+		mOutputRequestPending = false;
+		mDataMutex->Unlock();
 
-		if (inSize < kNewtonBufferSize)
-		{
-#ifdef DEBUG_SOUND
-			if (GetLog())
-			{
-				GetLog()->FLogLine("RAISEOUTPUTINTERRUPT SCHEDULEOUTPUT");
-			}
-#endif
-			RaiseOutputInterrupt();
-		}
+		pa_threaded_mainloop_lock(mPAMainLoop);
+		PAStreamWriteQueuedOutput(mOutputStream, pa_stream_writable_size(mOutputStream), false);
+		pa_threaded_mainloop_unlock(mPAMainLoop);
 	} else if (mOutputIsRunning)
 	{
 #ifdef DEBUG_SOUND
@@ -299,6 +293,9 @@ TPulseAudioSoundManager::ScheduleOutput(const KUInt8* inBuffer, KUInt32 inSize)
 			GetLog()->FLogLine("***** FROM NOS: ScheduleOutput no incoming data, STOP Output?");
 		}
 #endif
+		mDataMutex->Lock();
+		mOutputRequestPending = false;
+		mDataMutex->Unlock();
 		StopOutput();
 	}
 }
@@ -315,7 +312,10 @@ TPulseAudioSoundManager::StartOutput(void)
 		GetLog()->FLogLine("   _____  StartOutput  _____");
 	}
 #endif
+	mDataMutex->Lock();
 	mOutputIsRunning = true;
+	mOutputRequestPending = false;
+	mDataMutex->Unlock();
 	pa_threaded_mainloop_lock(mPAMainLoop);
 
 	if (pa_stream_is_corked(mOutputStream))
@@ -339,6 +339,7 @@ TPulseAudioSoundManager::StartOutput(void)
 	mPAOperation = pa_stream_trigger(mOutputStream, &SPAStreamOpCB, this);
 
 	pa_threaded_mainloop_unlock(mPAMainLoop);
+	RequestOutputInterrupt();
 #ifdef DEBUG_SOUND
 	if (GetLog())
 	{
@@ -362,6 +363,11 @@ TPulseAudioSoundManager::StopOutput(void)
 
 	pa_threaded_mainloop_lock(mPAMainLoop);
 
+	mDataMutex->Lock();
+	mOutputIsRunning = false;
+	mOutputRequestPending = false;
+	mDataMutex->Unlock();
+
 	mPAOperationDescr = "DRAIN";
 	mPAOperation = pa_stream_drain(mOutputStream, &SPAStreamOpCB, this);
 
@@ -371,7 +377,6 @@ TPulseAudioSoundManager::StopOutput(void)
 	}
 
 	pa_operation_unref(mPAOperation);
-	mOutputIsRunning = false;
 	pa_threaded_mainloop_unlock(mPAMainLoop);
 #ifdef DEBUG_SOUND
 	if (GetLog())
@@ -388,19 +393,23 @@ Boolean
 TPulseAudioSoundManager::OutputIsRunning(void)
 {
 	Boolean streamCorked = (Boolean) pa_stream_is_corked(mOutputStream);
+	Boolean outputIsRunning;
+	mDataMutex->Lock();
+	outputIsRunning = mOutputIsRunning;
+	mDataMutex->Unlock();
 #ifdef DEBUG_SOUND
 	if (GetLog())
 	{
 		GetLog()->FLogLine("   *****  OutputIsRunning: (PA Stream Corked? %s) (mOutputIsRunning? %s)",
 			streamCorked ? "true" : "false",
-			mOutputIsRunning ? "true" : "false");
-		GetLog()->FLogLine("   *****  OutputIsRunning returns %s\n", mOutputIsRunning ? "true" : "false");
+			outputIsRunning ? "true" : "false");
+		GetLog()->FLogLine("   *****  OutputIsRunning returns %s\n", outputIsRunning ? "true" : "false");
 	}
 #else
 	(void) streamCorked;
 #endif
 
-	return mOutputIsRunning;
+	return outputIsRunning;
 }
 
 void
@@ -455,10 +464,102 @@ TPulseAudioSoundManager::PAStreamUnderflowCallback(pa_stream* s, pa_threaded_mai
 		GetLog()->FLogLine("   *** PA Underflow occurred!");
 	}
 #endif
-	RaiseOutputInterrupt();
+	RequestOutputInterrupt();
 	if (mainloop)
 	{
 		pa_threaded_mainloop_signal(mainloop, 0);
+	}
+}
+
+void
+TPulseAudioSoundManager::PAStreamWriteCallback(pa_stream* s, unsigned int requested_bytes)
+{
+	PAStreamWriteQueuedOutput(s, requested_bytes, true);
+}
+
+void
+TPulseAudioSoundManager::PAStreamWriteQueuedOutput(pa_stream* s, size_t requested_bytes, Boolean requestMoreOutput)
+{
+	void* outBuffer = NULL;
+	size_t bytesToWrite = requested_bytes;
+	KUIntPtr bytesConsumed;
+
+	if (bytesToWrite == 0)
+	{
+		return;
+	}
+	if (mOutputBuffer == NULL || mDataMutex == NULL)
+	{
+		return;
+	}
+
+	mDataMutex->Lock();
+	bytesToWrite = MIN(mOutputBuffer->AvailableBytes(), bytesToWrite);
+	mDataMutex->Unlock();
+
+	if (bytesToWrite == 0)
+	{
+		if (requestMoreOutput)
+		{
+			RequestOutputInterrupt();
+		}
+		return;
+	}
+
+	if (pa_stream_begin_write(s, &outBuffer, &bytesToWrite) < 0)
+	{
+		return;
+	}
+	if (outBuffer == NULL || bytesToWrite == 0)
+	{
+		pa_stream_cancel_write(s);
+		return;
+	}
+
+	mDataMutex->Lock();
+	bytesConsumed = mOutputBuffer->Consume(outBuffer, bytesToWrite);
+	KUIntPtr bytesLeft = mOutputBuffer->AvailableBytes();
+	mDataMutex->Unlock();
+
+	if (bytesConsumed == 0)
+	{
+		pa_stream_cancel_write(s);
+		if (requestMoreOutput)
+		{
+			RequestOutputInterrupt();
+		}
+		return;
+	}
+
+	pa_stream_write(s, outBuffer, bytesConsumed, NULL, 0LL, PA_SEEK_RELATIVE);
+
+	if (requestMoreOutput && bytesLeft < kNewtonBufferSize)
+	{
+		RequestOutputInterrupt();
+	}
+}
+
+void
+TPulseAudioSoundManager::RequestOutputInterrupt(void)
+{
+	Boolean requestOutput = false;
+
+	if (mDataMutex == NULL)
+	{
+		return;
+	}
+
+	mDataMutex->Lock();
+	if (mOutputIsRunning && !mOutputRequestPending)
+	{
+		mOutputRequestPending = true;
+		requestOutput = true;
+	}
+	mDataMutex->Unlock();
+
+	if (requestOutput)
+	{
+		RaiseOutputInterrupt();
 	}
 }
 

--- a/Emulator/Sound/TPulseAudioSoundManager.cpp
+++ b/Emulator/Sound/TPulseAudioSoundManager.cpp
@@ -26,6 +26,7 @@
 #include "TPulseAudioSoundManager.h"
 
 // ANSI C * POSIX
+#include <algorithm>
 #include <assert.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -56,6 +57,12 @@
 // -------------------------------------------------------------------------- //
 TPulseAudioSoundManager::TPulseAudioSoundManager(TLog* inLog /* = nil */) :
 		TBufferedSoundManager(inLog),
+		mPAOperation(nullptr),
+		mPAOperationDescr(nullptr),
+		mOutputStream(nullptr),
+		mPAMainLoop(nullptr),
+		mPAMainLoopAPI(nullptr),
+		mPAContext(nullptr),
 		mOutputBuffer(new TCircleBuffer(
 			kNewtonBufferSizeInFrames * 4 * sizeof(KUInt16))),
 		mDataMutex(new TMutex()),
@@ -238,9 +245,11 @@ TPulseAudioSoundManager::~TPulseAudioSoundManager(void)
 		pa_stream_set_state_callback(mOutputStream, NULL, NULL);
 		// disconnect the stream
 		pa_stream_disconnect(mOutputStream);
+		pa_stream_unref(mOutputStream);
 		if (mPAContext)
 		{
 			pa_context_disconnect(mPAContext);
+			pa_context_unref(mPAContext);
 		}
 		if (mPAMainLoop)
 		{
@@ -494,7 +503,7 @@ TPulseAudioSoundManager::PAStreamWriteQueuedOutput(pa_stream* s, size_t requeste
 	}
 
 	mDataMutex->Lock();
-	bytesToWrite = MIN(mOutputBuffer->AvailableBytes(), bytesToWrite);
+	bytesToWrite = std::min<size_t>(mOutputBuffer->AvailableBytes(), bytesToWrite);
 	mDataMutex->Unlock();
 
 	if (bytesToWrite == 0)

--- a/Emulator/Sound/TPulseAudioSoundManager.h
+++ b/Emulator/Sound/TPulseAudioSoundManager.h
@@ -35,6 +35,7 @@
 #include "TBufferedSoundManager.h"
 
 class TMutex;
+class TCircleBuffer;
 
 ///
 /// Class to handle sound input/output and direct them to PulseAudio.
@@ -115,6 +116,8 @@ private:
 	void PAStreamUnderflowCallback(pa_stream* s, pa_threaded_mainloop* mainloop);
 
 	void PAStreamWriteCallback(pa_stream* s, unsigned int requested_bytes);
+	void PAStreamWriteQueuedOutput(pa_stream* s, size_t requested_bytes, Boolean requestMoreOutput);
+	void RequestOutputInterrupt(void);
 
 	static void
 	SPAStreamOpCB(pa_stream* stream, int success, void* userData)
@@ -137,8 +140,10 @@ private:
 	pa_threaded_mainloop* mPAMainLoop;
 	pa_mainloop_api* mPAMainLoopAPI;
 	pa_context* mPAContext;
+	TCircleBuffer* mOutputBuffer;
 	TMutex* mDataMutex;
 	Boolean mOutputIsRunning;
+	Boolean mOutputRequestPending;
 };
 
 #endif

--- a/K/Misc/TCircleBuffer.cpp
+++ b/K/Misc/TCircleBuffer.cpp
@@ -235,6 +235,84 @@ TCircleBuffer::Consume(void* outBuffer, KUIntPtr inAmount)
 	return amount;
 }
 
+// -------------------------------------------------------------------------- //
+//  * Peek( void*, KUIntPtr )
+// -------------------------------------------------------------------------- //
+KUIntPtr
+TCircleBuffer::Peek(void* outBuffer, KUIntPtr inAmount)
+{
+	KUIntPtr amount = inAmount;
+
+	// Copy data.
+	if (mConsumerCrsr <= mProducerCrsr)
+	{
+		// ---C123P---
+		KUIntPtr max = mProducerCrsr - mConsumerCrsr;
+		if (amount > max)
+		{
+			amount = max;
+		}
+
+		(void) ::memcpy(
+			outBuffer,
+			(const void*) (mBuffer + mConsumerCrsr),
+			amount);
+	} else
+	{
+		// 456P---C123
+		KUIntPtr max = mBufferSize + mProducerCrsr - mConsumerCrsr;
+		if (amount > max)
+		{
+			amount = max;
+		}
+
+		if (amount + mConsumerCrsr > mBufferSize)
+		{
+			KUIntPtr toEnd = mBufferSize - mConsumerCrsr;
+			KUIntPtr fromBeginning = amount - toEnd;
+			(void) ::memcpy(
+				outBuffer,
+				(const void*) (mBuffer + mConsumerCrsr),
+				toEnd);
+			(void) ::memcpy(
+				((KUInt8*) outBuffer) + toEnd,
+				(const void*) mBuffer,
+				fromBeginning);
+		} else
+		{
+			(void) ::memcpy(
+				outBuffer,
+				(const void*) (mBuffer + mConsumerCrsr),
+				amount);
+		}
+	}
+
+	return amount;
+}
+
+// -------------------------------------------------------------------------- //
+//  * Discard( KUIntPtr )
+// -------------------------------------------------------------------------- //
+void
+TCircleBuffer::Discard(KUIntPtr inAmount)
+{
+	KUIntPtr amount = inAmount;
+	KUIntPtr max = AvailableBytes();
+
+	if (amount > max)
+	{
+		amount = max;
+	}
+
+	if (amount + mConsumerCrsr > mBufferSize)
+	{
+		mConsumerCrsr = amount - (mBufferSize - mConsumerCrsr);
+	} else
+	{
+		mConsumerCrsr += amount;
+	}
+}
+
 // ============================================================================== //
 // Giving up on assembly language was the apple in our Garden of Eden:  Languages //
 // whose use squanders machine cycles are sinful.  The LISP machine now permits   //

--- a/K/Misc/TCircleBuffer.h
+++ b/K/Misc/TCircleBuffer.h
@@ -78,6 +78,22 @@ public:
 	KUIntPtr Consume(void* outBuffer, KUIntPtr inAmount);
 
 	///
+	/// Copy data for the consumer without advancing the consumer cursor.
+	///
+	/// \param outBuffer	where to write data.
+	/// \param inAmount		number of bytes to copy.
+	/// \return the number of bytes actually copied.
+	///
+	KUIntPtr Peek(void* outBuffer, KUIntPtr inAmount);
+
+	///
+	/// Advance the consumer cursor without copying data.
+	///
+	/// \param inAmount		number of bytes to discard.
+	///
+	void Discard(KUIntPtr inAmount);
+
+	///
 	/// Determine if the buffer is empty.
 	///
 	/// \return \c true if the buffer is empty, false otherwise.


### PR DESCRIPTION
Long sounds were choppy. This fixes it.
See commit messages for details.
I accidentally pushed these changes to another PR that I had open, but they are separate. I did take into account the AI code review from that initial PR though, and addressed them. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PulseAudio audio output by switching to buffered/queued delivery, reducing underflows and dropped audio during sustained playback.
  * Enhanced start/stop/shutdown coordination to make interruptions less likely.
* **Performance**
  * Audio delivery is now better synchronized with PulseAudio’s write requests for smoother, more consistent playback.
* **Technical Updates**
  * Improved internal buffering behavior with support for peeking and discarding data without advancing output prematurely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes PulseAudio output to buffer audio locally before writing it to the stream. The main changes are:

- A circular output buffer for queued audio samples.
- A PulseAudio write callback that drains queued output.
- Pending interrupt tracking for refill requests.
- Cleanup updates for stream callbacks, stream refs, and context refs.
- New `Peek` and `Discard` helpers on `TCircleBuffer`.

<h3>Confidence Score: 4/5</h3>

This is close, but one cleanup path should be fixed before merging.

- Partial PulseAudio construction can still leave the context alive after teardown.
- The main buffering and callback changes are otherwise scoped to the output path.

Emulator/Sound/TPulseAudioSoundManager.cpp

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Emulator/Sound/TPulseAudioSoundManager.cpp | Adds queued PulseAudio output, write-callback draining, refill request tracking, and cleanup changes. |
| Emulator/Sound/TPulseAudioSoundManager.h | Adds declarations and state for queued output and pending refill requests. |
| K/Misc/TCircleBuffer.cpp | Adds non-consuming buffer reads and explicit discard support. |
| K/Misc/TCircleBuffer.h | Exposes the new circular-buffer helper methods. |

<sub>Reviews (2): Last reviewed commit: ["Make PulseAudio queued writes transactio..."](https://github.com/pguyot/einstein/commit/15154c8d88ac282fdb3e3d71f7326c3abf423169) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43282059)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->