### PR TITLE
Merge #202: file sharing from Files app / share sheet (conflicts resolved)

### DIFF
--- a/Resources/iOSEinstein Storyboards-Info.plist
+++ b/Resources/iOSEinstein Storyboards-Info.plist
@@ -8,6 +8,29 @@
 	<string>iOSEinstein</string>
 	<key>CFBundleExecutable</key>
 	<string>iOSEinstein</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Newton Package Data</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.newton-inc.pkg</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Newton ROM Image</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.newton-inc.rom</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
@@ -31,7 +54,11 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>UISupportsDocumentBrowser</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
@@ -47,6 +74,50 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Newton Package Data</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.newton-inc.pkg</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pkg</string>
+					<string>PKG</string>
+					<string>newtonpkg</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Newton ROM Image</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.newton-inc.rom</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>rom</string>
+					<string>ROM</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Resources/iOSEinstein-Info.plist
+++ b/Resources/iOSEinstein-Info.plist
@@ -33,7 +33,11 @@
 	<string>MainWindow</string>
 	<key>NSMainNibFile~ipad</key>
 	<string>MainWindow_iPad</string>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>UISupportsDocumentBrowser</key>
 	<true/>
 	<key>UIStatusBarHidden</key>
 	<false/>

--- a/app/iEinstein/Classes/iEinsteinViewController.h
+++ b/app/iEinstein/Classes/iEinsteinViewController.h
@@ -47,6 +47,7 @@ class TLog;
 	TPlatformManager* mPlatformManager;
 	TLog* mLog;
 	int lastKnownScreenResolution;
+	UIAlertView* mMissingROMAlertView;
 }
 
 @property (retain, nonatomic) IBOutlet iEinsteinView* einsteinView;
@@ -95,6 +96,7 @@ class TLog;
 
 - (void)verifyDeleteFlashRAM:(int)withTag;
 - (void)explainMissingROM;
+- (BOOL)checkForROMImage;
 //- (void)openEinsteinMenu;
 
 - (int)allResourcesFound;


### PR DESCRIPTION
This new PR replaces #202 and #189. I will merge this is the AI review turns out well.

Resolves conflicts between #202 (support-file-sharing-from-ios) and master, which had modernized `iEinsteinViewController` from `UIActionSheet` to `UIAlertController` after #202 branched off.

## Summary
- Keeps master's modernized `UIAlertController`-based alerts and two-finger-tap Einstein menu.
- Folds in #202's ROM-handling logic: `loadROMImage` (extracted from `initEmulator`) and `checkForROMImage`, which lets the app detect a ROM added via the Files app or share sheet while running and dismiss the "missing ROM" alert automatically.
- Updates the missing-ROM alert message to mention the Files app / share sheet instead of iTunes File Sharing.
- Carries forward #202's other changes unmodified: `iEinsteinAppDelegate` file-open handling (ROM/pkg import via `openURL`/launch options) and the Info.plist entries enabling document browsing / file sharing.

## Test plan
- [x] `clang -fsyntax-only` against the iOS SDK on the changed `.mm`/`.h` files — no errors, only pre-existing deprecation warnings.
- [ ] Build and run in Xcode / iOS Simulator: verify missing-ROM alert, dropping a ROM via Files app dismisses it and starts the emulator, and pkg install via share sheet still works.

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)